### PR TITLE
Remove unnecessary characters from create view

### DIFF
--- a/resources/views/transactions/create.twig
+++ b/resources/views/transactions/create.twig
@@ -193,7 +193,6 @@
                     </div>
                 </div>
             </div>
-            #}
         </div>
     </form>
 


### PR DESCRIPTION
The `#}`characters are not parsed and are displayed in the view.

<img width="242" alt="bildschirmfoto 2017-01-21 um 13 30 16" src="https://cloud.githubusercontent.com/assets/1080923/22174404/f56b2506-dfdd-11e6-98ec-34b6ab58c0bd.png">

(PS: Just started using firefly as a YNAB replacement. Keep up the good work! I hope I can contribute to the project soon 😃 )