### PR TITLE
Fix smooth curves around data points in graphs

### DIFF
--- a/public/js/ff/charts.defaults.js
+++ b/public/js/ff/charts.defaults.js
@@ -11,6 +11,11 @@
 /** global: accounting */
 
 var defaultChartOptions = {
+    elements: {
+        line : {
+            cubicInterpolationMode: 'monotone'
+        }
+    },
     scales: {
         xAxes: [
             {


### PR DESCRIPTION
The graphs created using Chart.js are using smooth curves that look pleasant, but overshoot or undershoot the values between data points.
We can set `cubicInterpolationMode` to `monotone` in order to avoid this behavior.

Example of what was happening: 
![undershooting curve](https://cloud.githubusercontent.com/assets/910672/22856980/534928b4-f07b-11e6-9e30-f41117e46f52.jpg)