### PR TITLE
Use Docker volumes created by docker-compose to persist data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /public/storage
 /vendor
 /.idea
-/firefly-db-storage
 Homestead.json
 Homestead.yaml
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /public/storage
 /vendor
 /.idea
+/firefly-db-storage
 Homestead.json
 Homestead.yaml
 .env

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,6 +4,7 @@ services:
   firefly-db:
     volumes:
       - firefly-dev-storage:/var/lib/mysql
+      - .:/var/www/firefly-iii
   firefly-app:
     environment:
       - INIT_DATABASE=yes

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,8 +4,9 @@ services:
   firefly-db:
     volumes:
       - firefly-dev-storage:/var/lib/mysql
-      - .:/var/www/firefly-iii
   firefly-app:
+    volumes:
+      - .:/var/www/firefly-iii
     environment:
       - INIT_DATABASE=yes
       - FF_APP_ENV=development

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,14 @@
+version: '2'
+
+services:
+  firefly-db:
+    volumes:
+      - firefly-dev-storage:/var/lib/mysql
+  firefly-app:
+    environment:
+      - INIT_DATABASE=yes
+      - FF_APP_ENV=development
+
+volumes:
+  firefly-dev-storage:
+    driver: local

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,4 +5,8 @@ services:
     environment:
       - FF_APP_ENV=production
     volumes:
-      - ./storage:/var/www/firefly-iii/storage
+      - firefly-app-storage:/var/www/firefly-iii/storage
+
+volumes:
+  firefly-app-storage:
+    driver: local

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,6 @@ version: '2'
 
 services:
   firefly-app:
-    container_name: firefly-iii
     environment:
       - FF_APP_ENV=production
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,33 +1,9 @@
 version: '2'
 
 services:
-  firefly-db:
-    image: mysql:8
-    environment:
-      - MYSQL_DATABASE=firefly_db
-      - MYSQL_USER=firefly_db
-      - MYSQL_PASSWORD=firefly_db_secret
-      - MYSQL_RANDOM_ROOT_PASSWORD=yes
-    volumes:
-      - firefly-db-storage:/var/lib/mysql
-
   firefly-app:
-    image: firefly-iii
     container_name: firefly-iii
-    build: .
     environment:
-      - FF_DB_HOST=firefly-db
-      - FF_DB_NAME=firefly_db
-      - FF_DB_USER=firefly_db
-      - FF_DB_PASSWORD=firefly_db_secret
-      - FF_APP_KEY=SomeRandomStringOf32CharsExactly
       - FF_APP_ENV=production
-    ports:
-      - "80:80"
-    links:
-      - firefly-db
     volumes:
       - ./storage:/var/www/firefly-iii/storage
-volumes:
-  firefly-db-storage:
-    driver: local

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,7 +9,7 @@ services:
       - MYSQL_PASSWORD=firefly_db_secret
       - MYSQL_RANDOM_ROOT_PASSWORD=yes
     volumes:
-      - ./firefly-db-storage:/var/lib/mysql
+      - firefly-db-storage:/var/lib/mysql
 
   firefly-app:
     image: firefly-iii
@@ -28,3 +28,6 @@ services:
       - firefly-db
     volumes:
       - ./storage:/var/www/firefly-iii/storage
+volumes:
+  firefly-db-storage:
+    driver: local

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,25 +9,22 @@ services:
       - MYSQL_PASSWORD=firefly_db_secret
       - MYSQL_RANDOM_ROOT_PASSWORD=yes
     volumes:
-      - firefly-storage:/var/lib/mysql
+      - ./firefly-db-storage:/var/lib/mysql
 
   firefly-app:
     image: firefly-iii
-    build:
-      context: .
+    container_name: firefly-iii
+    build: .
     environment:
-      - INIT_DATABASE=yes
       - FF_DB_HOST=firefly-db
       - FF_DB_NAME=firefly_db
       - FF_DB_USER=firefly_db
       - FF_DB_PASSWORD=firefly_db_secret
       - FF_APP_KEY=SomeRandomStringOf32CharsExactly
-      - FF_APP_ENV=development
+      - FF_APP_ENV=production
     ports:
       - "80:80"
     links:
       - firefly-db
-
-volumes:
-  firefly-storage:
-    driver: local
+    volumes:
+      - ./storage:/var/www/firefly-iii/storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,25 +9,22 @@ services:
       - MYSQL_PASSWORD=firefly_db_secret
       - MYSQL_RANDOM_ROOT_PASSWORD=yes
     volumes:
-      - firefly-storage:/var/lib/mysql
+      - ./firefly-db-storage:/var/lib/mysql
 
   firefly-app:
     image: firefly-iii
-    build:
-      context: .
+    container_name: firefly-iii
+    build: .
     environment:
-      - INIT_DATABASE=yes
       - FF_DB_HOST=firefly-db
       - FF_DB_NAME=firefly_db
       - FF_DB_USER=firefly_db
       - FF_DB_PASSWORD=firefly_db_secret
       - FF_APP_KEY=SomeRandomStringOf32CharsExactly
-      - FF_APP_ENV=development
+      - FF_APP_ENV=production
     ports:
       - "80:80"
     links:
       - firefly-db
-
-volumes:
-  firefly-storage:
-    driver: local
+    volumes:
+      - ./storage:/var/www/firefly-iii/storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,16 +13,13 @@ services:
 
   firefly-app:
     image: firefly-iii
-    build:
-      context: .
+    build: .
     environment:
-      - INIT_DATABASE=yes
       - FF_DB_HOST=firefly-db
       - FF_DB_NAME=firefly_db
       - FF_DB_USER=firefly_db
       - FF_DB_PASSWORD=firefly_db_secret
       - FF_APP_KEY=SomeRandomStringOf32CharsExactly
-      - FF_APP_ENV=development
     ports:
       - "80:80"
     links:


### PR DESCRIPTION
As mentioned in #561 the current docker-compose setup does not persist data which means that all data will be gone when the Docker containers are stopped. This PR resolves that by creating a separate docker-compose file that is suitable for production use. It uses a Docker volume to store data for the app.

After starting (using `docker-compose -f docker-compose.prod.yml up -d`), you still need to seed the database (can't be done automatically for production AFAIK) by running `docker exec -ti firefly-iii php artisan migrate:refresh --seed`. After this, you should be ready to go and your data will be available after restarts.