### PR TITLE
Transactions without budget should only return budgetable transactions

### DIFF
--- a/app/Helpers/Collector/JournalCollector.php
+++ b/app/Helpers/Collector/JournalCollector.php
@@ -518,6 +518,7 @@ class JournalCollector implements JournalCollectorInterface
             function (EloquentBuilder $q) {
                 $q->whereNull('budget_transaction.budget_id');
                 $q->whereNull('budget_transaction_journal.budget_id');
+                $q->where('transaction_types.type', '=', TransactionType::WITHDRAWAL);
             }
         );
 


### PR DESCRIPTION
When I was assigning transactions to budgets I noticed that in the view there were transactions which could not be assigned to budgets (Transfers, revenue, opening balance)

This pull request improves this view, only return budgetable transactions

Tests ran fine