### PR TITLE
Fix saving a tag’s date

### DIFF
--- a/app/Http/Requests/TagFormRequest.php
+++ b/app/Http/Requests/TagFormRequest.php
@@ -45,7 +45,6 @@ class TagFormRequest extends Request
             $longitude = null;
             $zoomLevel = null;
         }
-        $date = $this->get('date') ?? '';
 
         $data = [
             'tag'         => $this->string('tag'),

--- a/app/Http/Requests/TagFormRequest.php
+++ b/app/Http/Requests/TagFormRequest.php
@@ -49,7 +49,7 @@ class TagFormRequest extends Request
 
         $data = [
             'tag'         => $this->string('tag'),
-            'date'        => $this->date($date),
+            'date'        => $this->date('date'),
             'description' => $this->string('description'),
             'latitude'    => $latitude,
             'longitude'   => $longitude,


### PR DESCRIPTION
The `date` function takes the fieldname where a date is stored, not the literal date.