### PR TITLE
Set default piggy for new transaction

### DIFF
--- a/resources/views/transactions/single/create.twig
+++ b/resources/views/transactions/single/create.twig
@@ -77,7 +77,7 @@
                         {{ ExpandedForm.text('tags') }}
 
                         <!-- RELATE THIS TRANSFER TO A PIGGY BANK -->
-                        {{ ExpandedForm.select('piggy_bank_id', piggies) }}
+                        {{ ExpandedForm.select('piggy_bank_id', piggies, '0') }}
 
                     </div>
                 </div>


### PR DESCRIPTION
Fixes #605. By explicitly setting the selected piggybank to the 0-piggy, new transactions will not inadvertently get coupled to a piggybank if the piggy’s name starts with characters that get sorted before `(` (such as `!` or `’`).