### PR TITLE
Changed to get relative path and not absolute path

### DIFF
--- a/resources/views/partials/favicons.twig
+++ b/resources/views/partials/favicons.twig
@@ -1,6 +1,6 @@
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-<link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-<link rel="manifest" href="/manifest.json">
-<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+<link rel="icon" type="image/png" href="favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" href="favicon-16x16.png" sizes="16x16">
+<link rel="manifest" href="manifest.json">
+<link rel="mask-icon" href="safari-pinned-tab.svg" color="#5bbad5">
 <meta name="theme-color" content="#3c8dbc">


### PR DESCRIPTION
If you access with absolute path, favicon don't appear on site and manifest.json isn't load on android Chrome. Get 404 error