### PR TITLE
Fix en_US translation: no_accounts_imperative_revenue.

### DIFF
--- a/resources/lang/en_US/firefly.php
+++ b/resources/lang/en_US/firefly.php
@@ -1024,7 +1024,7 @@ return [
     'no_accounts_create_expense'            => 'Create an expense account',
     'no_accounts_title_revenue'             => 'Let\'s create a revenue account!',
     'no_accounts_intro_revenue'             => 'You have no revenue accounts yet. Revenue accounts are the places where you receive money from, such as your employer.',
-    'no_accounts_imperative_revenue'        => 'Expense accounts are created automatically when you create transactions, but you can create one manually too, if you want. Let\'s create one now:',
+    'no_accounts_imperative_revenue'        => 'Revenue accounts are created automatically when you create transactions, but you can create one manually too, if you want. Let\'s create one now:',
     'no_accounts_create_revenue'            => 'Create a revenue account',
     'no_budgets_title_default'              => 'Let\'s create a budget',
     'no_budgets_intro_default'              => 'You have no budgets yet. Budgets are used to organise your expenses into logical groups, which you can give a soft-cap to limit your expenses.',


### PR DESCRIPTION
There was a small typo/error on the create revenue account page.