### PR TITLE
Fix formatting when currency symbol is separated and follows amount

### DIFF
--- a/app/Support/Amount.php
+++ b/app/Support/Amount.php
@@ -130,7 +130,7 @@ class Amount
         $result    = $format->symbol . $space . $formatted;
 
         if (!$precedes) {
-            $result = $space . $formatted . $format->symbol;
+            $result = $formatted . $space . $format->symbol;
         }
 
         if ($coloured === true) {


### PR DESCRIPTION
When currency symbol follows amount, space should be between amount and symbol, not before amount.

Just like PHP does it:
```
> php -r 'setlocale(LC_ALL, "pl_PL.utf8"); echo money_format("%n", 12345.67);'
12.345,67 zł
> php -r 'setlocale(LC_ALL, "pl_PL.utf8"); print_r(localeconv());'
Array
(
    [decimal_point] => ,
    [thousands_sep] =>
    [int_curr_symbol] => PLN
    [currency_symbol] => zł
    [mon_decimal_point] => ,
    [mon_thousands_sep] => .
    [positive_sign] =>
    [negative_sign] => -
    [int_frac_digits] => 2
    [frac_digits] => 2
    [p_cs_precedes] => 0
    [p_sep_by_space] => 1
    [n_cs_precedes] => 0
    [n_sep_by_space] => 1
    [p_sign_posn] => 1
    [n_sign_posn] => 1
    [grouping] => Array
        (
        )

    [mon_grouping] => Array
        (
            [0] => 3
            [1] => 3
        )

)
```