### PR TITLE
Docker: Use working directory instead of hardcoded dist version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Ignore composer specific files and vendor folder
+composer.phar
+composer.lock
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 /node_modules
 /public/storage
-/vendor
 Homestead.json
 Homestead.yaml
 .env
 public/google*.html
 report.html
+
+### Composer ###
+composer.phar
+/vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,15 +34,17 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 # Copy Apache Configs
 COPY ./docker/apache-firefly.conf /etc/apache2/sites-available/000-default.conf
 
-WORKDIR /var/www/firefly-iii
+ENV FIREFLY_PATH /var/www/firefly-iii
+
+WORKDIR $FIREFLY_PATH
 
 # The working directory
-COPY . /var/www/firefly-iii/
+COPY . $FIREFLY_PATH
 
-RUN chown -R www-data:www-data /var/www && chmod -R 775 /var/www/firefly-iii/storage
+RUN chown -R www-data:www-data /var/www && chmod -R 775 $FIREFLY_PATH/storage
 
 RUN composer install --prefer-dist --no-dev --no-scripts
 
 EXPOSE 80
 
-ENTRYPOINT ["/var/www/firefly-iii/docker/entrypoint.sh"]
+ENTRYPOINT ["docker/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,18 +23,26 @@ RUN docker-php-ext-install -j$(nproc) curl gd intl json mcrypt readline tidy zip
 # Generate locales supported by firefly
 RUN echo "en_US.UTF-8 UTF-8\nde_DE.UTF-8 UTF-8\nnl_NL.UTF-8 UTF-8\npt_BR.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
 
-COPY docker/apache2.conf /etc/apache2/apache2.conf
+COPY ./docker/apache2.conf /etc/apache2/apache2.conf
+
 # Enable apache mod rewrite..
 RUN a2enmod rewrite
 
 # Setup the Composer installer
-run curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-RUN cd /var/www && composer create-project grumpydictator/firefly-iii --no-dev --prefer-dist firefly-iii 4.6.4
-COPY docker/entrypoint.sh /var/www/firefly-iii/docker/entrypoint.sh
-ADD docker/apache-firefly.conf /etc/apache2/sites-available/000-default.conf
-RUN chown -R www-data:www-data /var/www && chmod -R 775 /var/www/firefly-iii/storage
+# Copy Apache Configs
+COPY ./docker/apache-firefly.conf /etc/apache2/sites-available/000-default.conf
 
 WORKDIR /var/www/firefly-iii
+
+# The working directory
+COPY . /var/www/firefly-iii/
+
+RUN chown -R www-data:www-data /var/www && chmod -R 775 /var/www/firefly-iii/storage
+
+RUN composer install --prefer-dist --no-dev --no-scripts
+
 EXPOSE 80
+
 ENTRYPOINT ["/var/www/firefly-iii/docker/entrypoint.sh"]


### PR DESCRIPTION
- By using the current (.) working directory, we can get the latest changes in the Docker image.
  If the building of Docker images is automated, it will automatically pick up the checked out version.
- Rearrange some Docker layers things that don't invalidate that much.
