### PR TITLE
Enable mod_ssl in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ COPY ./docker/apache2.conf /etc/apache2/apache2.conf
 # Enable apache mod rewrite..
 RUN a2enmod rewrite
 
+# Enable apache mod ssl..
+RUN a2enmod ssl
+
 # Setup the Composer installer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 


### PR DESCRIPTION
While Apache configuration file will still have to be customize, this makes one file less to modify when running Docker containers