### PR TITLE
Fix issue with accounts in select map not matching

### DIFF
--- a/app/Import/Mapper/OpposingAccounts.php
+++ b/app/Import/Mapper/OpposingAccounts.php
@@ -57,7 +57,7 @@ class OpposingAccounts implements MapperInterface
             }
             $list[$accountId] = $name;
         }
-        $list = array_merge([0 => trans('import.map_do_not_map')], $list);
+        $list = ["0" => trans('import.map_do_not_map')] + $list;
 
         return $list;
     }


### PR DESCRIPTION
When mapping Opposing Accounts the select input's values are incorrect and do not match account ids.

Fixes # (if relevant)

Changes in this pull request:

- 
- 
- 

@JC5
