### PR TITLE
Fix charts in Internet Explorer

### DIFF
--- a/public/js/ff/charts.js
+++ b/public/js/ff/charts.js
@@ -88,7 +88,9 @@ const verticalLinePlugin = {
 
     afterDatasetsDraw: function (chart, easing) {
         if (chart.config.lineAtIndex) {
-            chart.config.lineAtIndex.forEach(pointIndex => this.renderVerticalLine(chart, pointIndex));
+            chart.config.lineAtIndex.forEach(function(pointIndex) {
+                this.renderVerticalLine(chart, pointIndex);
+            }, this);
         }
     }
 };


### PR DESCRIPTION
As it stands, I happened to notice that the charts in Firefly-III don't render on IE.  
Turns out it seems like IE has no support for arrow function expression (and thus throws a syntax error).

Fortunately, the fix seems to be quite a simple one.    Once I changed the particular `=>` instance at L91, charts.js, the charts seem to be back again on IE.    So basically this patch's to make IE happy.

Tested it out on my machine, 4.6.13 with this patch, and both Chrome and IE 11 successfully render the charts.
