### PR TITLE
Workaround IE tab order issue on js initial select

### DIFF
--- a/public/js/ff/guest.js
+++ b/public/js/ff/guest.js
@@ -22,5 +22,5 @@ $(function () {
     "use strict";
 
     // Focus first visible form element.
-    $("form input:enabled:visible:first").first().select()
+    $("form input:enabled:visible:first").first().focus().select()
 });


### PR DESCRIPTION
(Sorry if it's another IE (quirk) fix) 
(This [SO question](https://stackoverflow.com/questions/628235/tab-order-issue-in-ie-with-initial-javascript-select-of-field-in-form) actually identifies succinctly the issue that, so happens, I've come across and I gratefully adopt a proposed fix from one of its answers)

_tl; dr: ~~probably~~ apparently an IE bug, but hopefully a simple (and not very intrusive to other browsers) fix to revive some convenience to IE users_

#### To reproduce:
(I think it probably occurs only in IE)
1. Type in the address bar (say `demo.firefly-iii.org`) to navigate to the login page.
The site will load.  The js kicks in and selects the first input (ie `Email address`) field.
2. With the blinking text cursor in the textbox, type in something, like`demo@firefly`.  Press Tab.
3.  Instead of going to the next field (`Password`), the blinking cursor disappears 
(and no field seems to be in focus).
[The user will then have to press tab a few times to cycle back to the next field or resort to the mouse.]
#### The issue
As will become apparent (and actually described in the SO thread), the focus actually tabs out to the address bar (as if, I shall add, incidentally back to the 'original' focus back in step 1).   What happens is, I believe, on calling `select()` by the js on the first textbox, IE somehow didn't update its 'focus' which stays where it left off (aka the address bar after typing in the web address).   That probably explains why, from my experiments, it only exhibits in some cases where the user presses Enter on the web address to load the page, but not in others, say, when one hits F5 to reload the page (when the 'old' focus is already inside the webpage).

All in all, fair to say it'll be another IE quirk.
#### Proposed fix
As suggested in the above SO thread: 
> Focus, _then_ select.

I tried as suggested to place a `focus()` before the `select()` call in the js, and it seems to work.  It cycles to the (next) `Password` field as expected.

Hopefully the extra `focus()` call will not incur too much an overhead to other browsers.

