### PR TITLE
Add Docker support for sqlite

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -19,7 +19,7 @@ TRUSTED_PROXIES=${TRUSTED_PROXIES}
 
 # Database credentials. Make sure the database exists. I recommend a dedicated user for Firefly III
 # If you use SQLite, set connection to `sqlite` and remove the database, username and password settings.
-DB_CONNECTION=mysql
+DB_CONNECTION=${FF_DB_CONNECTION}
 DB_HOST=${FF_DB_HOST}
 DB_PORT=3306
 DB_DATABASE=${FF_DB_NAME}

--- a/docker/docker.env
+++ b/docker/docker.env
@@ -1,5 +1,6 @@
 FF_APP_ENV=local
 FF_APP_KEY=S0m3R@nd0mString0f32Ch@rsEx@ct1y
+FF_DB_CONNECTION=mysql
 FF_DB_HOST=
 FF_DB_NAME=
 FF_DB_USER=

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,6 +9,10 @@ cat .env.docker | envsubst > .env
 # if the database is an sqlite database, we need to remove all non-connection variables
 if [ "$FF_DB_CONNECTION" == "sqlite" ]; then
     sed -i '/DB_/{/DB_CONNECTION/!d;}' .env
+
+    # make sure own the sqlite database file
+    chown -R www-data:www-data $FIREFLY_PATH/storage/database
+    chmod -R 775 $FIREFLY_PATH/storage/database
 fi
 
 cat .env

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,6 +10,11 @@ cat .env.docker | envsubst > .env
 if [ "$FF_DB_CONNECTION" == "sqlite" ]; then
     sed -i '/DB_/{/DB_CONNECTION/!d;}' .env
 
+    if [ ! -e "$FIREFLY_PATH/storage/database/database.sqlite" ]; then 
+        # check if the database file exists, if not, create one
+        touch $FIREFLY_PATH/storage/database/database.sqlite
+    fi
+
     # make sure own the sqlite database file
     chown -R www-data:www-data $FIREFLY_PATH/storage/database
     chmod -R 775 $FIREFLY_PATH/storage/database

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,7 +4,14 @@
 chown -R www-data:www-data $FIREFLY_PATH/storage/export $FIREFLY_PATH/storage/upload
 chmod -R 775 $FIREFLY_PATH/storage/export $FIREFLY_PATH/storage/upload
 
-cat .env.docker | envsubst > .env && cat .env
+cat .env.docker | envsubst > .env
+
+# if the database is an sqlite database, we need to remove all non-connection variables
+if [ "$FF_DB_CONNECTION" == "sqlite" ]; then
+    sed -i '/DB_/{/DB_CONNECTION/!d;}' .env
+fi
+
+cat .env
 composer dump-autoload
 php artisan optimize
 php artisan package:discover


### PR DESCRIPTION
Changes in this pull request:

- Extra environment variable `FF_DB_CONNECTION` can now be used, and will be reflected in the `.env` file.
- All DB variables not used by sqlite will be removed from the `.env` file
- An sqlite database file is created if there isn't one available

@JC5

There is no open issue for this, but I'm a big fan of Docker and I saw that even though Firefly itself supports sqlite, the Dockerfile did not. This is a small extension to make this possible. Any other databases should still be working, and it is even possible to switch between database engines if one wants to (because the `.env` file is still built from scratch on each boot).

I'm already using this in my own local environment, and it works great. Should you accept this pull request, I will also update the Docker entry in the docs to reflect this new feature.