### PR TITLE
Add support for other database types

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -19,9 +19,9 @@ TRUSTED_PROXIES=${TRUSTED_PROXIES}
 
 # Database credentials. Make sure the database exists. I recommend a dedicated user for Firefly III
 # If you use SQLite, set connection to `sqlite` and remove the database, username and password settings.
-DB_CONNECTION=mysql
+DB_CONNECTION=${FF_DB_CONNECTION:-mysql}
 DB_HOST=${FF_DB_HOST}
-DB_PORT=3306
+DB_PORT=${FF_DB_PORT:-3306}
 DB_DATABASE=${FF_DB_NAME}
 DB_USERNAME=${FF_DB_USER}
 DB_PASSWORD=${FF_DB_PASSWORD}


### PR DESCRIPTION
Changes in this pull request:

- Allows users to use sqlite with docker (see sample compose file below)

```yaml
version: "3.2"
services:
  firefly_iii_app:
    environment:
      - FF_APP_KEY
      - FF_APP_ENV=local
      - FF_DB_CONNECTION=sqlite
      - FF_DB_NAME=/var/www/firefly-iii/storage/database/database.sqlite
      - TRUSTED_PROXIES=**
    image: jc5x/firefly-iii
    container_name: firefly
    restart: always
    expose:
      - 80
    volumes:
      - "./firefly-iii/export:/var/www/firefly-iii/storage/export"
      - "./firefly-iii/upload:/var/www/firefly-iii/storage/upload"
      - "./firefly-iii/database:/var/www/firefly-iii/storage/database"
```

@JC5
