### PR TITLE
Remove the 'php artisan optimize' command from the entrypoint.sh file…

### DIFF
--- a/.deploy/docker/entrypoint.sh
+++ b/.deploy/docker/entrypoint.sh
@@ -6,7 +6,6 @@ chmod -R 775 $FIREFLY_PATH/storage/export $FIREFLY_PATH/storage/upload
 
 cat .env.docker | envsubst > .env && cat .env
 composer dump-autoload
-php artisan optimize
 php artisan package:discover
 php artisan firefly:instructions install
 exec apache2-foreground


### PR DESCRIPTION
… since the optimize command was removed from artisan in 5.6

Fixes # (if relevant)

Changes in this pull request:

- 
- 
- 

@JC5
