### PR TITLE
Make database connection configurable for docker

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -22,7 +22,7 @@ LOG_CHANNEL=${LOG_CHANNEL}
 
 # Database credentials. Make sure the database exists. I recommend a dedicated user for Firefly III
 # If you use SQLite, set connection to `sqlite` and remove the database, username and password settings.
-DB_CONNECTION=mysql
+DB_CONNECTION=${FF_DB_CONNECTION-mysql}
 DB_HOST=${FF_DB_HOST}
 DB_PORT=${FF_DB_PORT}
 DB_DATABASE=${FF_DB_NAME}


### PR DESCRIPTION
This adds the option to configure DB_CONNECTION and DB_PORT via docker
env variables, so the usage of the Image is not limited to mysql.
