### PR TITLE
Fix alignment of sidebar-icons

### DIFF
--- a/resources/views/partials/menu-sidebar.twig
+++ b/resources/views/partials/menu-sidebar.twig
@@ -55,7 +55,7 @@
     </li>
     <li class="{{ activeRoutePartial('transactions') }} treeview" id="transaction-menu">
         <a href="#">
-            <i class="fa fa-repeat"></i>
+            <i class="fa fa-repeat fa-fw"></i>
             <span>{{ 'transactions'|_ }}</span>
             <span class="pull-right-container">
               <i class="fa fa-angle-left pull-right"></i>


### PR DESCRIPTION
I noticed a minor thing which was bothering me. The Icons in the sidebar weren't align correctly (the fa-repeat icon). This change should fix this.

I hope it's okay, that i didn't ask you before :smile: 

Changes in this pull request:

- Add "fa-fw" class to "fa-repeat" icon

@JC5

#### broken version
![sidebar1](https://user-images.githubusercontent.com/31184224/39406107-c1011546-4bb1-11e8-8a69-c2a0329b5b53.png)

#### fixed version
![sidebar2](https://user-images.githubusercontent.com/31184224/39406112-df2bf5a4-4bb1-11e8-9708-2045295f8cfc.png)

