### PR TITLE
Update Sandstorm build instructions

### DIFF
--- a/.sandstorm/Vagrantfile
+++ b/.sandstorm/Vagrantfile
@@ -9,9 +9,16 @@ VM_NAME = File.basename(File.dirname(File.dirname(__FILE__))) + "_sandstorm_#{Ti
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+# ugly hack to prevent hashicorp's bitrot. See https://github.com/hashicorp/vagrant/issues/9442
+# this setting is required for pre-2.0 vagrant, but causes an error as of 2.0.3,
+# remove entirely when confident nobody uses vagrant 1.x for anything.
+unless Vagrant::DEFAULT_SERVER_URL.frozen?
+  Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Base on the Sandstorm snapshots of the official Debian 8 (jessie) box.
-  config.vm.box = "sandstorm/debian-jessie64"
+  config.vm.box = "debian/contrib-jessie64"
 
   if Vagrant.has_plugin?("vagrant-vbguest") then
     # vagrant-vbguest is a Vagrant plugin that upgrades

--- a/.sandstorm/global-setup.sh
+++ b/.sandstorm/global-setup.sh
@@ -9,6 +9,10 @@ CURL_OPTS="--silent --show-error"
 echo localhost > /etc/hostname
 hostname localhost
 
+# Install curl that is needed below.
+apt-get update
+apt-get install -y curl
+
 # The following line copies stderr through stderr to cat without accidentally leaving it in the
 # output file. Be careful when changing. See: https://github.com/sandstorm-io/vagrant-spk/pull/159
 curl $CURL_OPTS https://install.sandstorm.io/ 2>&1 > /host-dot-sandstorm/caches/install.sh | cat

--- a/.sandstorm/setup.sh
+++ b/.sandstorm/setup.sh
@@ -32,7 +32,7 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E9C74FEEA2098A6E
 add-apt-repository "deb http://packages.dotdeb.org jessie all"
 
 # add another repos
-apt-get install apt-transport-https lsb-release ca-certificates
+apt-get install -y apt-transport-https lsb-release ca-certificates
 wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
 


### PR DESCRIPTION
Note that vagrant-spk currently uses Stretch, but that'd likely require more changes and testing on your other build files. I was unable to fully test the Firefly III build because I was doing this on a Windows box, and vagrant-spk + Windows + symbolic links = sadness.

Changes in this pull request:

- Updated box to official Jessie 64
- Made one of your install commands accept without prompt in setup.sh
- Ensured Vagrantfile works on more versions of Vagrant

@JC5