### PR TITLE
BUGFIX: Initial user not set as owner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ yarn-error.log
 public/google*.html
 report.html
 composer.phar
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ yarn-error.log
 public/google*.html
 report.html
 composer.phar
-/.idea

--- a/app/Repositories/User/UserRepository.php
+++ b/app/Repositories/User/UserRepository.php
@@ -58,7 +58,7 @@ class UserRepository implements UserRepositoryInterface
         }
 
         try {
-            $user->roles()->attach($role);
+            $user->roles()->attach($roleObject);
         } catch (QueryException $e) {
             // don't care
             Log::info(sprintf('Query exception when giving user a role: %s', $e->getMessage()));


### PR DESCRIPTION
Fixes #1589

Changes in this pull request:

- Used the right object to attach as role. Instead of String now the real Role object is used

@JC5
