### PR TITLE
fixed Dockerfile for cURL and cron

### DIFF
--- a/.deploy/docker/crontab
+++ b/.deploy/docker/crontab
@@ -1,0 +1,1 @@
+* * * * * root /artisan schedule:run >> /var/log/cron.log

--- a/.deploy/docker/entrypoint.sh
+++ b/.deploy/docker/entrypoint.sh
@@ -26,3 +26,6 @@ cat .env.docker | envsubst > .env
 composer dump-autoload
 php artisan package:discover
 php artisan firefly:instructions install
+service rsyslog start
+service cron start
+exec apache2-foreground

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,64 @@
-FROM webdevops/php-nginx:7.2
+FROM php:7.1-apache
+
+# If building on a RPi, use --build-arg cores=3 to use all cores when compiling
+# to speed up the image build
+ARG CORES
+ENV CORES ${CORES:-1}
 
 ENV FIREFLY_PATH /app
 WORKDIR $FIREFLY_PATH
 ADD . $FIREFLY_PATH
 
-# gettext is used to update the .env file when the container launches.
-RUN apt-get update -y && apt-get install -y --no-install-recommends gettext-base && apt-get clean
+# install packages
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends libcurl4-openssl-dev \
+                                               zlib1g-dev \
+                                               libjpeg62-turbo-dev \
+                                               wget \
+                                               libpng-dev \
+                                               libicu-dev \
+                                               libedit-dev \
+                                               libtidy-dev \
+                                               libxml2-dev \
+                                               libsqlite3-dev \
+                                               libpq-dev \
+                                               libbz2-dev \
+                                               gettext-base \
+                                               cron \
+                                               rsyslog \
+                                               locales && \
+                                               apt-get clean && \
+                                               rm -rf /var/lib/apt/lists/*
+
+# Install latest curl
+RUN cd /tmp && \
+    wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz && \
+    tar -xvf openssl-${OPENSSL_VERSION}.tar.gz && \
+    cd openssl-${OPENSSL_VERSION} && \
+    ./config && \
+    make -j${CORES} && \
+    make install
+
+RUN cd /tmp && \
+    wget https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz && \
+    tar -xvf curl-${CURL_VERSION}.tar.gz && \
+    cd curl-${CURL_VERSION} && \
+    ./configure --with-ssl --host=$(gcc -dumpmachine) && \
+    make -j${CORES} && \
+    make install
+
+# Make sure that libcurl is using the newer curl libaries
+RUN echo "/usr/local/lib" >> /etc/ld.so.conf.d/00-curl.conf && ldconfig
+
+# Create the log file to be able to run tail
+RUN touch /var/log/cron.log
+
+# Setup cron job
+COPY .deploy/docker/crontab /etc/cron.d/crontab
+RUN chmod 0644 /etc/cron.d/crontab
+
+# Install PHP exentions.
+RUN docker-php-ext-install -j$(nproc) gd intl tidy zip bcmath pdo_mysql bz2 pdo_pgsql
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
@@ -13,22 +66,30 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 # Generate locales supported by Firefly III
 RUN echo "en_US.UTF-8 UTF-8\nde_DE.UTF-8 UTF-8\nfr_FR.UTF-8 UTF-8\nit_IT.UTF-8 UTF-8\nnl_NL.UTF-8 UTF-8\npl_PL.UTF-8 UTF-8\npt_BR.UTF-8 UTF-8\nru_RU.UTF-8 UTF-8\ntr_TR.UTF-8 UTF-8\n\n" > /etc/locale.gen && locale-gen
 
+# copy Apache config to correct spot.
+COPY ./.deploy/docker/apache2.conf /etc/apache2/apache2.conf
+
+# Enable apache mod rewrite..
+RUN a2enmod rewrite
+
+# Enable apache mod ssl..
+RUN a2enmod ssl
+
 # Create volumes
 VOLUME $FIREFLY_PATH/storage/export $FIREFLY_PATH/storage/upload
 
+# Enable default site (Firefly III)
+COPY ./.deploy/docker/apache-firefly.conf /etc/apache2/sites-available/000-default.conf
+
 # Make sure we own Firefly III directory
 RUN chown -R $APPLICATION_GID:$APPLICATION_UID /var/www && chmod -R 775 $FIREFLY_PATH/storage
-
-# Add cron job
-RUN docker-service enable cron
-RUN docker-cronjob '0 3 * * * application cd /app/ && php artisan firefly:cron'
 
 # Run composer
 ENV COMPOSER_ALLOW_SUPERUSER 1
 RUN composer install --prefer-dist --no-dev --no-scripts --no-suggest
 
-# Copy nginx config to correct spot.
-COPY ./.deploy/docker/vhost.conf /opt/docker/etc/nginx/vhost.conf
+# Expose port 80
+EXPOSE 80
 
-# Copy entrypoint script to correct spot:
-COPY ./.deploy/docker/entrypoint.sh /opt/docker/provision/entrypoint.d/default.sh
+# Run entrypoint thing
+ENTRYPOINT [".deploy/docker/entrypoint.sh"]


### PR DESCRIPTION
Fixes #1464 

Changes in this pull request:

- Fixed installation of cURL
Building the image on RPI broke when running curl with a libcurl version mismatch (compare versions with `curl -V`). This mismatch was also present on other platforms, but for some reason didn't break the image builds. Fixed by [loading the new libraries](https://github.com/ErikFontanel/firefly-iii/blob/efd5ceb40533af47db97d9784716544ff6c7d0ce/Dockerfile#L50-L51)

- Added CORES build argument (defaults to 1) to take advantage of multiple cores when building on a RPI to speed up the build process from ~2h to ~45min. Usage: `docker build --build-arg CORES=4 . `.

- Removed some php extensions which are already included by default in the base image

- Added the crontab in a separate file and run it through `entrypoint.sh` and installed rsyslog as @dicastro mentioned.

@JC5
Tested building the image on a 2015 Macbook Pro and Raspberry Pi 3B both running `Docker version 18.06.0-ce, build 0ffa825`. I haven't tested cURL / bunq because I don't have a bunq API key and can't be bothered to create one ;). But with a broken cURL installation, installing composer fails anyway.