### PR TITLE
Can have link in success message to the transaction it refers to

### DIFF
--- a/app/Http/Controllers/Transaction/SingleController.php
+++ b/app/Http/Controllers/Transaction/SingleController.php
@@ -369,7 +369,8 @@ class SingleController extends Controller
 
         event(new StoredTransactionJournal($journal, $data['piggy_bank_id']));
 
-        session()->flash('success_uri', (string)trans('firefly.stored_journal', ['description' => "<a href='/transactions/show/{$journal->id}'>{$journal->description}</a>"]));
+        session()->flash('success_uri', route('transactions.show', [$journal->id]));
+        session()->flash('success', (string)trans('firefly.stored_journal', ['description' => $journal->description]));
         app('preferences')->mark();
 
         // @codeCoverageIgnoreStart

--- a/app/Http/Controllers/Transaction/SingleController.php
+++ b/app/Http/Controllers/Transaction/SingleController.php
@@ -369,7 +369,7 @@ class SingleController extends Controller
 
         event(new StoredTransactionJournal($journal, $data['piggy_bank_id']));
 
-        session()->flash('success', (string)trans('firefly.stored_journal', ['description' => $journal->description]));
+        session()->flash('success_uri', (string)trans('firefly.stored_journal', ['description' => "<a href='/transactions/show/{$journal->id}'>{$journal->description}</a>"]));
         app('preferences')->mark();
 
         // @codeCoverageIgnoreStart

--- a/resources/views/partials/flashes.twig
+++ b/resources/views/partials/flashes.twig
@@ -14,17 +14,17 @@
         <button type="button" class="close" data-dismiss="alert">
             <span>&times;</span><span class="sr-only">{{ 'close'|_ }}</span>
         </button>
-        <strong>{{ 'flash_success'|_ }}</strong> {{ session('success') }}
-    </div>
-{% endif %}
 
-{# SUCCESS MESSAGE WITH URL (ALWAYS SINGULAR) #}
-{% if session_has('success_uri') %}
-    <div class="alert alert-success alert-dismissible" role="alert">
-        <button type="button" class="close" data-dismiss="alert">
-            <span>&times;</span><span class="sr-only">{{ 'close'|_ }}</span>
-        </button>
-        <strong>{{ 'flash_success'|_ }}</strong> {{ session('success_uri') | striptags('<a>') | raw }}
+        {% if session_has('success_uri') %}
+            <a href="{{ session('success_uri') }}">
+        {% endif %}
+
+        <strong>{{ 'flash_success'|_ }}</strong> {{ session('success') }}
+
+        {% if session_has('success_uri') %}
+            </a>
+        {% endif %}
+
     </div>
 {% endif %}
 

--- a/resources/views/partials/flashes.twig
+++ b/resources/views/partials/flashes.twig
@@ -18,6 +18,16 @@
     </div>
 {% endif %}
 
+{# SUCCESS MESSAGE WITH URL (ALWAYS SINGULAR) #}
+{% if session_has('success_uri') %}
+    <div class="alert alert-success alert-dismissible" role="alert">
+        <button type="button" class="close" data-dismiss="alert">
+            <span>&times;</span><span class="sr-only">{{ 'close'|_ }}</span>
+        </button>
+        <strong>{{ 'flash_success'|_ }}</strong> {{ session('success_uri') | striptags('<a>') | raw }}
+    </div>
+{% endif %}
+
 {# INFO MESSAGE (CAN BE MULTIPLE) #}
 {% if session_has('info') %}
     <div class="alert alert-info alert-dismissible" role="alert">


### PR DESCRIPTION
Fixes # (if relevant)

Changes in this pull request:
Adds option for messages to contain a link (issue #1623), and makes single transactions use that option

@JC5 
