### PR TITLE
Trust Heroku load balancer

### DIFF
--- a/.env.heroku
+++ b/.env.heroku
@@ -19,7 +19,7 @@ TZ=UTC
 
 # APP_URL and TRUSTED_PROXIES are useful when using Docker and/or a reverse proxy.
 APP_URL=http://localhost
-TRUSTED_PROXIES=
+TRUSTED_PROXIES=**
 
 # The log channel defines where your log entries go to.
 LOG_CHANNEL=syslog


### PR DESCRIPTION
Fix insecure warning in browser when deploying to Heroku

Changes in this pull request:

- TRUSTED_PROXIES environment variable

@JC5
