### PR TITLE
2FA QR doesn't show up due to CSP error

### DIFF
--- a/app/Http/Middleware/SecureHeaders.php
+++ b/app/Http/Middleware/SecureHeaders.php
@@ -57,7 +57,7 @@ class SecureHeaders
             "form-action 'self'",
             "font-src 'self'",
             "connect-src 'self'",
-            "img-src 'self'",
+            "img-src 'self' data:",
         ];
 
         $featurePolicies = [


### PR DESCRIPTION
Error in console:
Refused to load the image 'data:image/png;base64,...' because it violates the following Content Security Policy directive: "img-src 'self'".

Relevant stackoverflow fix:
https://stackoverflow.com/questions/18447970/content-security-policy-data-not-working-for-base64-images-in-chrome-28

Changes in this pull request:
- Adding data scheme to CSP config of image sources

@JC5
