### PR TITLE
Add expected behavior to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -12,6 +12,9 @@ I am running Firefly III version x.x.x
 **Steps to reproduce**
 What do you need to do to trigger this bug?
 
+**Expected behavior**
+What do you expect to see after those steps?
+
 **Extra info**
 Please add extra info here, such as OS, browser, and the output from the /debug page of your Firefly III installation (click the version at the bottom).
 


### PR DESCRIPTION
Helps to understand how the bug violates what the user expect to happen in normal scenario.

Changes in this pull request:

- Github bug report template

@JC5
