### PR TITLE
Make sure PHP executable is being resolved by composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,13 +112,13 @@
       "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump"
     ],
     "post-update-cmd": [
-      "php artisan firefly:upgrade-database",
-      "php artisan firefly:verify",
-      "php artisan firefly:instructions update",
-      "php artisan passport:install"
+      "@php artisan firefly:upgrade-database",
+      "@php artisan firefly:verify",
+      "@php artisan firefly:instructions update",
+      "@php artisan passport:install"
     ],
     "post-install-cmd": [
-      "php artisan firefly:instructions install"
+      "@php artisan firefly:instructions install"
     ]
   },
   "config": {


### PR DESCRIPTION
There are situations where php executable is not in path or is not called `php` in those cases `composer update` and `composer install` will break or might use php version which might not be the same as the one running the composer process.

One of the examples can be that on your system you have at least two versions of PHP. One available as `php` the other as `php.7.1` and so on.
If you were to run `php7.1 /path/to/composer.phar install` in the project directory, the composer will be executed by `php7.1` but the artisan scripts will be run under `php` executable and most likely will fail.

Defining scripts in `composer.json` which reference `php` executable using `@php` token avoids this issue.

/ref https://getcomposer.org/doc/articles/scripts.md#executing-php-scripts
/ref https://github.com/composer/composer/commit/b0000617cc7bc481d839eb3c59d81bbcbaef34a4
/ref https://github.com/symfony/process/blob/master/PhpExecutableFinder.php

Changes in this pull request:

- replaced `php artisan` calls with `@php artisan` to ensure correct PHP executable resolution

@JC5
