### PR TITLE
Fix bunq import "Undefined index: apply_rules"

### DIFF
--- a/app/Support/Import/JobConfiguration/Bunq/ChooseAccountsHandler.php
+++ b/app/Support/Import/JobConfiguration/Bunq/ChooseAccountsHandler.php
@@ -79,7 +79,7 @@ class ChooseAccountsHandler implements BunqJobConfigurationInterface
         $config     = $this->repository->getConfiguration($this->importJob);
         $accounts   = $config['accounts'] ?? [];
         $mapping    = $data['account_mapping'] ?? [];
-        $applyRules = 1 === (int)$data['apply_rules'];
+        $applyRules = 1 === (int)($data['apply_rules'] ?? 0);
         $final      = [];
 
         /*


### PR DESCRIPTION
When using the bunq import and unchecking "apply rules" gave an error. Same as https://github.com/firefly-iii/firefly-iii/issues/1538

@JC5
