### PR TITLE
remove first slash in mass transaction changes

### DIFF
--- a/public/js/ff/transactions/list.js
+++ b/public/js/ff/transactions/list.js
@@ -67,7 +67,7 @@ function goToMassEdit() {
         baseHref = bases[0].href;
     }
 
-    window.location.href = baseHref + '/transactions/mass/edit/' + checkedArray;
+    window.location.href = baseHref + 'transactions/mass/edit/' + checkedArray;
     return false;
 }
 
@@ -87,7 +87,7 @@ function goToBulkEdit() {
         baseHref = bases[0].href;
     }
 
-    window.location.href = baseHref + '/transactions/bulk/edit/' + checkedArray;
+    window.location.href = baseHref + 'transactions/bulk/edit/' + checkedArray;
     return false;
 }
 
@@ -106,7 +106,7 @@ function goToMassDelete() {
     if (bases.length > 0) {
         baseHref = bases[0].href;
     }
-    window.location.href = baseHref + '/transactions/mass/delete/' + checkedArray;
+    window.location.href = baseHref + 'transactions/mass/delete/' + checkedArray;
     return false;
 }
 


### PR DESCRIPTION
Fixes # (if relevant)

![image](https://user-images.githubusercontent.com/550499/45924384-aa70de00-bf07-11e8-986b-747daca30951.png)


Maybe bug (not verified) when mass editing/deleting transactions when Firefly installed in directory.
Couldn't find similar coding pattern in other js files from a quick look (referencing base in uri),
what should be the recommended pattern in this case?


Changes in this pull request:

- remove first slash in mass transaction changes
- 
- 

@JC5
