### PR TITLE
Made shebang more portable

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DATABASE=./storage/database/database.sqlite
 DATABASECOPY=./storage/database/databasecopy.sqlite


### PR DESCRIPTION
Fixes # (if relevant)

Changes in this pull request:

- Changed shebang in test.so to /usr/bin/env bash to be more portable.

@JC5
