### PR TITLE
Fixed locales lang error on Heroku build platform

### DIFF
--- a/.locales
+++ b/.locales
@@ -1,0 +1,9 @@
+en_US
+de_DE
+fr_FR
+it_IT
+nl_NL
+pl_PL
+pt_BR
+ru_RU
+tr_TR

--- a/app.json
+++ b/app.json
@@ -51,6 +51,9 @@
   "buildpacks": [
     {
       "url": "heroku/php"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-locale"
     }
   ],
   "env": {


### PR DESCRIPTION
Starting from heroku 16 stack the language packs are not included by default: https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-locale

Fixes [#8](https://github.com/firefly-iii/help/issues/8)

Changes in this pull request:

- Fixed locales lang error on Heroku build platform

@JC5 