### PR TITLE
Add links to transaction from dates in bill, closes #1771

### DIFF
--- a/app/Repositories/Bill/BillRepository.php
+++ b/app/Repositories/Bill/BillRepository.php
@@ -381,7 +381,9 @@ class BillRepository implements BillRepositoryInterface
      */
     public function getPaidDatesInRange(Bill $bill, Carbon $start, Carbon $end): Collection
     {
-        $dates = $bill->transactionJournals()->before($end)->after($start)->get(['transaction_journals.date'])->pluck('date');
+        $dates = $bill->transactionJournals()->before($end)->after($start)->get([
+            'transaction_journals.id','transaction_journals.date'
+        ])->pluck('date', 'id');
 
         return $dates;
     }

--- a/resources/views/list/bills.twig
+++ b/resources/views/list/bills.twig
@@ -97,8 +97,11 @@
             #}
             {% if entry.paid_dates|length > 0 and entry.active %}
                 <td class="paid_in_period text-success" data-value="{{ entry.paid_dates[0] }}">
-                    {% for date in entry.paid_dates %}
-                        {{ formatDate(date, monthAndDayFormat) }}<br/>
+                    {% for transaction_id, date in entry.paid_dates %}
+                        <a href="{{ route('transactions.show',transaction_id) }}">
+                            {{ formatDate(date, monthAndDayFormat) }}
+                        </a>
+                        <br/>
                     {% endfor %}
                 </td>
                 <td class="expected_in_period hidden-sm hidden-xs" data-value="{{ entry.next_expected_match }}">


### PR DESCRIPTION
Fixes #1771 (if relevant)

Changes in this pull request:

- Adds the link to the transaction from dates in the bill
- Does not implement said changes in the Vue component (as it is unused currently)

@JC5
