### PR TITLE
bills: match attachment route with the icon

### DIFF
--- a/resources/views/bills/show.twig
+++ b/resources/views/bills/show.twig
@@ -115,12 +115,12 @@
                                         <div class="btn-group btn-group-xs">
                                             <a href="{{ route('attachments.edit', att.id) }}" class="btn btn-default"><i class="fa fa-pencil"></i></a>
                                             <a href="{{ route('attachments.delete', att.id) }}" class="btn btn-danger"><i class="fa fa-trash"></i></a>
-                                            <a href="{{ route('attachments.view', att.id) }}" class="btn btn-default"><i class="fa fa-download"></i></a>
+                                            <a href="{{ route('attachments.download', att.id) }}" class="btn btn-default"><i class="fa fa-download"></i></a>
                                         </div>
                                     </td>
                                     <td>
                                         <i class="fa {{ att.mime|mimeIcon }}"></i>
-                                        <a href="{{ route('attachments.download', att.id) }}" title="{{ att.filename }}">
+                                        <a href="{{ route('attachments.view', att.id) }}" title="{{ att.filename }}">
                                             {% if att.title %}
                                                 {{ att.title }}
                                             {% else %}


### PR DESCRIPTION
Fixes # (if relevant)

Changes in this pull request:

- bills: match attachment route with the icon

@JC5
