### PR TITLE
Using translation of "start balance" for initial balance transaction

### DIFF
--- a/app/Services/Internal/Support/AccountServiceTrait.php
+++ b/app/Services/Internal/Support/AccountServiceTrait.php
@@ -35,6 +35,7 @@ use FireflyIII\Models\TransactionJournal;
 use FireflyIII\Models\TransactionType;
 use FireflyIII\Services\Internal\Destroy\JournalDestroyService;
 use FireflyIII\User;
+use Illuminate\Support\Facades\Lang;
 use Log;
 use Validator;
 
@@ -217,7 +218,7 @@ trait AccountServiceTrait
      */
     public function storeOpposingAccount(User $user, string $name): Account
     {
-        $name .= ' initial balance';
+        $name .= ' ' . strtolower(Lang::get('firefly.start_balance'));
         Log::debug('Going to create an opening balance opposing account.');
         /** @var AccountFactory $factory */
         $factory = app(AccountFactory::class);


### PR DESCRIPTION
Fixes #1815 

Changes in this pull request:

- added translation to FireflyIII\Services\Internal\Support\AccountServiceTrait::storeOpposingAccount()

Maybe a bit simplistic approach, other option is to just use "Initial balance" or a new translation. @JC5
