### PR TITLE
Fixed missing CSP directive and value

### DIFF
--- a/app/Http/Middleware/SecureHeaders.php
+++ b/app/Http/Middleware/SecureHeaders.php
@@ -55,9 +55,10 @@ class SecureHeaders
             "style-src 'self' 'unsafe-inline'",
             "base-uri 'self'",
             "form-action 'self'",
-            "font-src 'self'",
+            "font-src 'self' data: https://fonts.gstatic.com",
             "connect-src 'self'",
             "img-src 'self' data: https://api.tiles.mapbox.com",
+            "manifest-src 'self'",
         ];
 
         $featurePolicies = [

--- a/app/Http/Middleware/SecureHeaders.php
+++ b/app/Http/Middleware/SecureHeaders.php
@@ -55,7 +55,7 @@ class SecureHeaders
             "style-src 'self' 'unsafe-inline'",
             "base-uri 'self'",
             "form-action 'self'",
-            "font-src 'self' data: https://fonts.gstatic.com",
+            "font-src 'self'",
             "connect-src 'self'",
             "img-src 'self' data: https://api.tiles.mapbox.com",
             "manifest-src 'self'",


### PR DESCRIPTION
Changes in this pull request:

- Fixed CSP value that block Google Fonts and fonts loaded by (local) base64 code
- Added CSP directive to load manifest file ([site.webmanifest](https://github.com/firefly-iii/firefly-iii/tree/master/public/site.webmanifest))

@JC5
