### PR TITLE
Added memcached support and zend opcache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && apt-get install -y libpng-dev \
                                             gettext-base \
                                             libldap2-dev \
                                             libpq-dev \
-                                            locales && \
+                                            locales \
+                                            libmemcached-dev && \
                                             apt-get clean && \
                                             rm -rf /var/lib/apt/lists/*
 
@@ -35,7 +36,9 @@ RUN chown -R www-data:www-data /var/www && \
     chmod -R 775 $FIREFLY_PATH/storage && \
     a2enmod rewrite && a2enmod ssl && \
     docker-php-ext-configure ldap --with-libdir=lib/$(gcc -dumpmachine)/ && \
-    docker-php-ext-install -j$(nproc) zip bcmath ldap gd pdo_pgsql pdo_mysql intl && \
+    docker-php-ext-install -j$(nproc) zip bcmath ldap gd pdo_pgsql pdo_mysql intl opcache && \
+    pecl install memcached-3.1.3 && \
+    docker-php-ext-enable memcached && \
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
     echo "de_DE.UTF-8 UTF-8\nen_US.UTF-8 UTF-8\nes_ES.UTF-8 UTF-8\nfr_FR.UTF-8 UTF-8\nid_ID.UTF-8 UTF-8\nit_IT.UTF-8 UTF-8\nnl_NL.UTF-8 UTF-8\npl_PL.UTF-8 UTF-8\npt_BR.UTF-8 UTF-8\nru_RU.UTF-8 UTF-8\ntr_TR.UTF-8 UTF-8\nzh_TW.UTF-8 UTF-8\n\n" > /etc/locale.gen && \
     locale-gen && \


### PR DESCRIPTION
Changes in this pull request:

- Added libmemcached-dev package to apt-install
- Added opcache to php-extensions to install
- Added pecl installation of memcached-3.1.3 (used explicit version as recommended on https://hub.docker.com/_/php/ )

Memcached can be used by providing the following environment variables:
MEMCACHED_PERSISTENT_ID=[random-string-unique-for-installation]
MEMCACHED_HOST=[adres-of-memcached-server>]
CACHE_DRIVER=memcached

@JC5
