### PR TITLE
Fix delete-account confirmation

### DIFF
--- a/resources/views/v1/profile/delete-account.twig
+++ b/resources/views/v1/profile/delete-account.twig
@@ -43,7 +43,7 @@
                         </div>
                     </div>
                     <div class="box-footer">
-                        <button type="submit" onclick="confirm('{{ 'are_you_sure'|_ }}')" class="btn btn-danger pull-right">
+                        <button type="submit" onclick="return confirm('{{ 'are_you_sure'|_ }}');" class="btn btn-danger pull-right">
                             {{ 'delete_account_button'|_ }}
                         </button>
                     </div>


### PR DESCRIPTION
Steps to reproduce:
- Go to Options, Profile, Delete account
- Enter password
- Click "DELETE your account"
- Confirmation dialog appears: "Are you sure? You cannot undo this." (OK/Cancel)
- Click **Cancel**

Expected behavior:
- Account is not deleted

What happens instead:
- Account is deleted

Changes in this pull request:
- Do not delete account if user cancels confirmation dialog

@JC5