### PR TITLE
fixed typo

### DIFF
--- a/resources/lang/pl_PL/firefly.php
+++ b/resources/lang/pl_PL/firefly.php
@@ -1062,7 +1062,7 @@ return [
     'journal-amount'                          => 'Faktyczna kwota',
     'name'                                    => 'Nazwa',
     'date'                                    => 'Data',
-    'paid'                                    => 'Zpłacone',
+    'paid'                                    => 'Zapłacone',
     'unpaid'                                  => 'Niezapłacone',
     'day'                                     => 'Dzień',
     'budgeted'                                => 'Zabudżetowano',


### PR DESCRIPTION
fixed typo - was 'zpłacone', should be 'zapłacone'