### PR TITLE
missing meta tag for ios

### DIFF
--- a/resources/views/v1/layout/default.twig
+++ b/resources/views/v1/layout/default.twig
@@ -6,6 +6,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="robots" content="noindex, nofollow, noarchive, noodp, NoImageIndex, noydir">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+
     <title>
         {% if subTitle %}
             {{ subTitle }} »

--- a/resources/views/v1/layout/empty.twig
+++ b/resources/views/v1/layout/empty.twig
@@ -8,6 +8,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' name='viewport'>
+    <meta name="apple-mobile-web-app-capable" content="yes">
 
     {# CSS things #}
 

--- a/resources/views/v1/layout/guest.twig
+++ b/resources/views/v1/layout/guest.twig
@@ -4,6 +4,8 @@
     <base href="{{ route('index') }}/">
     <meta charset="UTF-8">
     <meta name="robots" content="noindex, nofollow, noarchive, noodp, NoImageIndex, noydir">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+
     <title>Firefly III
 
         {% if title != "Firefly" and title != "" %}

--- a/resources/views/v1/layout/install.twig
+++ b/resources/views/v1/layout/install.twig
@@ -8,6 +8,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no' name='viewport'>
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <link href="v1/css/app.css?v={{ FF_VERSION }}" rel="stylesheet" type="text/css"/>
     <link href="v1/lib/adminlte/css/AdminLTE.min.css?v={{ FF_VERSION }}" rel="stylesheet" type="text/css"/>
     <link href="v1/css/firefly.css?v={{ FF_VERSION }}" rel="stylesheet" type="text/css"/>


### PR DESCRIPTION
Fixes:
url bar on home screen web app visible on ios and not on android.
Tested on ios. Want more space on screen when using firefly III on mobile as homescreen app.

Changes in this pull request:

- added 
```html
    <meta name="apple-mobile-web-app-capable" content="yes">
``` 
@JC5
