### PR TITLE
Fix LDAP auth configuration paths.

### DIFF
--- a/config/ldap_auth.php
+++ b/config/ldap_auth.php
@@ -143,7 +143,7 @@ return [
 
     'scopes' => $scopes,
 
-    'usernames' => [
+    'identifiers' => [
 
         /*
         |--------------------------------------------------------------------------
@@ -173,8 +173,8 @@ return [
 
         'ldap' => [
 
-            'discover'     => envNonEmpty('ADLDAP_DISCOVER_FIELD', 'userprincipalname'),
-            'authenticate' => envNonEmpty('ADLDAP_AUTH_FIELD', 'distinguishedname'),
+            'locate_users_by'     => envNonEmpty('ADLDAP_DISCOVER_FIELD', 'userprincipalname'),
+            'bind_users_by' => envNonEmpty('ADLDAP_AUTH_FIELD', 'distinguishedname'),
 
         ],
 

--- a/database/migrations/2019_03_11_223700_fixldap.php
+++ b/database/migrations/2019_03_11_223700_fixldap.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Class ChangesForV4713
+ */
+class ChangesForV4713 extends Migration
+{
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table(
+            'users', function (Blueprint $table) {
+            $table->dropColumn(['objectguid']);
+        }
+        );
+    }
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        /**
+         * ADLdap2 appears to require the ability to store an objectguid for LDAP users
+         * now. To support this, we add the column.
+         */
+        Schema::table(
+            'users', function (Blueprint $table) {
+            $table->uuid('objectguid')->nullable()->after('id');
+        }
+        );
+    }
+}


### PR DESCRIPTION
This commit fixes parameters broken in the latest version of `adldap2`.

Specifically:

* `adldap` auth parameters have changed in the latest version.
  * "usernames" has become `identities` and `discover` has changed to
    `discover_users_by`, `auth` has changed to `bind_users_by`
* Add the missing objectguid field to the users table for adldap2.
  * This is added as a nullable (optional) field at the moment to support
    tracking LDAP users as adldap2 wants to.

Fixes issue #1933 (completely).

Changes in this pull request:

- Database migration for `objectguid`
- Change the paths in `config/ldap_auth.php` to match up `adldap2`

With these changes I was able to get authentication with FreeIPA working correctly versus current master.

@JC5
