### PR TITLE
F/split piggy

### DIFF
--- a/app/Console/Commands/VerifyDatabase.php
+++ b/app/Console/Commands/VerifyDatabase.php
@@ -348,7 +348,8 @@ class VerifyDatabase extends Command
                 }
 
                 $type = $journal->transactionType->type;
-                if (TransactionType::TRANSFER !== $type) {
+                // should be one of the 3 types
+                if (TransactionType::TRANSFER !== $type && TransactionType::DEPOSIT !== $type && TransactionType::WITHDRAWAL !== $type) {
                     $event->transaction_journal_id = null;
                     $event->save();
                     $this->line(sprintf('Piggy bank #%d was referenced by an invalid event. This has been fixed.', $event->piggy_bank_id));

--- a/app/Factory/PiggyBankEventFactory.php
+++ b/app/Factory/PiggyBankEventFactory.php
@@ -19,7 +19,7 @@
  * along with Firefly III. If not, see <http://www.gnu.org/licenses/>.
  */
 /** @noinspection MultipleReturnStatementsInspection */
-declare(strict_types=1);
+declare (strict_types = 1);
 
 namespace FireflyIII\Factory;
 
@@ -84,8 +84,10 @@ class PiggyBankEventFactory
 
             return null;
         }
-
-        $piggyRepos->addAmountToRepetition($repetition, $amount);
+        // only add if not Transfer
+        if (!$journal->isTransfer()) {
+            $piggyRepos->addAmountToRepetition($repetition, $amount);
+        }
         $event = $piggyRepos->createEventWithJournal($piggyBank, $amount, $journal);
         Log::debug(sprintf('Created piggy bank event #%d', $event->id));
 

--- a/app/Http/Controllers/Chart/PiggyBankController.php
+++ b/app/Http/Controllers/Chart/PiggyBankController.php
@@ -52,6 +52,32 @@ class PiggyBankController extends Controller
         $this->generator = app(GeneratorInterface::class);
     }
 
+    public function currencies($curr): JsonResponse
+    {
+        $curl = curl_init();
+
+        curl_setopt_array($curl, array(
+            CURLOPT_URL => "https://api.exchangeratesapi.io/latest?base=".$curr,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_ENCODING => "",
+            CURLOPT_MAXREDIRS => 10,
+            CURLOPT_TIMEOUT => 30,
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+            CURLOPT_CUSTOMREQUEST => "GET",
+        ));
+
+        $response = curl_exec($curl);
+        $err = curl_error($curl);
+
+        curl_close($curl);
+
+        if ($err) {
+            return response()->json("error");
+        } else {
+            return response()->json($response);
+        }
+    }
+
     /**
      * Shows the piggy bank history.
      *

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -107,6 +107,21 @@ class Account extends Model
     }
 
     /**
+     * get piggy bank totals from events
+     */
+    public function piggyBankSummaries(): HasMany
+    {
+        $events = $this->hasMany(PiggyBankEvent::class)
+            ->selectRaw('piggy_bank_id,piggy_banks.name,sum(amount) as Total, 
+            (select SUM(p2.amount) FROM `piggy_bank_events` as p2 where p2.from_account_id=piggy_bank_events.account_id and p2.piggy_bank_id=piggy_bank_events.piggy_bank_id) as Transfers')
+            ->join('piggy_banks', 'piggy_bank_events.piggy_bank_id', '=', 'piggy_banks.id')
+            ->groupBy('piggy_banks.id')
+            ->groupBy('piggy_bank_events.account_id');
+
+        return $events;
+    }
+
+    /**
      * @return HasMany
      * @codeCoverageIgnore
      */

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -117,6 +117,8 @@ class Account extends Model
             ->join('piggy_banks', 'piggy_bank_events.piggy_bank_id', '=', 'piggy_banks.id')
             ->where('piggy_banks.deleted_at', null)
             ->groupBy('piggy_banks.id')
+            ->groupBy('piggy_bank_events.piggy_bank_id')
+            ->groupBy('piggy_banks.name')
             ->groupBy('piggy_bank_events.account_id');
 
         return $events;

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -115,6 +115,7 @@ class Account extends Model
             ->selectRaw('piggy_bank_id,piggy_banks.name,sum(amount) as Total, 
             (select SUM(p2.amount) FROM `piggy_bank_events` as p2 where p2.from_account_id=piggy_bank_events.account_id and p2.piggy_bank_id=piggy_bank_events.piggy_bank_id) as Transfers')
             ->join('piggy_banks', 'piggy_bank_events.piggy_bank_id', '=', 'piggy_banks.id')
+            ->where('piggy_banks.deleted_at', null)
             ->groupBy('piggy_banks.id')
             ->groupBy('piggy_bank_events.account_id');
 

--- a/app/Models/PiggyBank.php
+++ b/app/Models/PiggyBank.php
@@ -135,6 +135,7 @@ class PiggyBank extends Model
             ->join('account_meta', 'accounts.id', '=', 'account_meta.account_id')
             ->where('account_meta.name', 'currency_id')
             ->groupBy('piggy_bank_events.account_id')
+            ->groupBy('accounts.name')
             ->groupBy('account_meta.data')
             ->groupBy('piggy_bank_events.piggy_bank_id');
         return $events;

--- a/app/Models/PiggyBank.php
+++ b/app/Models/PiggyBank.php
@@ -128,7 +128,7 @@ class PiggyBank extends Model
      */
     public function accounts(): HasMany
     {
-        $events = $this->hasMany(PiggyBankEvent::class)->selectRaw('piggy_bank_events.account_id as id,accounts.name,(SUM(piggy_bank_events.amount) + (select SUM(p1.transfer) FROM `piggy_bank_events` as p1 where p1.account_id=piggy_bank_events.account_id) - (select SUM(p2.transfer) FROM `piggy_bank_events` as p2 where p2.from_account_id=piggy_bank_events.account_id)) as total')->join('accounts', 'piggy_bank_events.account_id', '=', 'accounts.id')->groupBy('piggy_bank_events.account_id');
+        $events = $this->hasMany(PiggyBankEvent::class)->selectRaw('piggy_bank_events.account_id as id,accounts.name, SUM(piggy_bank_events.amount) as sum, (select SUM(p1.transfer) FROM `piggy_bank_events` as p1 where p1.account_id=piggy_bank_events.account_id and p1.piggy_bank_id=piggy_bank_events.piggy_bank_id) as transfers, (select SUM(p2.transfer) FROM `piggy_bank_events` as p2 where p2.from_account_id=piggy_bank_events.account_id and p2.piggy_bank_id=piggy_bank_events.piggy_bank_id) as withdrawals')->join('accounts', 'piggy_bank_events.account_id', '=', 'accounts.id')->groupBy('piggy_bank_events.account_id')->groupBy('piggy_bank_events.piggy_bank_id');
         return $events;
     }
 

--- a/app/Models/PiggyBank.php
+++ b/app/Models/PiggyBank.php
@@ -129,7 +129,7 @@ class PiggyBank extends Model
     public function accounts(): HasMany
     {
         $events = $this->hasMany(PiggyBankEvent::class)->selectRaw('
-            piggy_bank_events.account_id as id,accounts.name, `account_meta`.`data`, SUM(piggy_bank_events.amount) as sum, (select SUM(p1.transfer) FROM `piggy_bank_events` as p1 where p1.account_id=piggy_bank_events.account_id and p1.piggy_bank_id=piggy_bank_events.piggy_bank_id) as transfers, (select SUM(p2.transfer) FROM `piggy_bank_events` as p2 where p2.from_account_id=piggy_bank_events.account_id and p2.piggy_bank_id=piggy_bank_events.piggy_bank_id) as withdrawals
+            piggy_bank_events.account_id as id,accounts.name, `account_meta`.`data`, SUM(piggy_bank_events.amount) as sum, (select SUM(p1.amount) FROM `piggy_bank_events` as p1 where p1.account_id=piggy_bank_events.account_id and p1.piggy_bank_id=piggy_bank_events.piggy_bank_id) as transfers, (select SUM(p2.amount) FROM `piggy_bank_events` as p2 where p2.from_account_id=piggy_bank_events.account_id and p2.piggy_bank_id=piggy_bank_events.piggy_bank_id) as withdrawals
         ')
             ->join('accounts', 'piggy_bank_events.account_id', '=', 'accounts.id')
             ->join('account_meta', 'accounts.id', '=', 'account_meta.account_id')

--- a/app/Models/PiggyBankEvent.php
+++ b/app/Models/PiggyBankEvent.php
@@ -54,7 +54,7 @@ class PiggyBankEvent extends Model
             'date'       => 'date',
         ];
     /** @var array Fields that can be filled */
-    protected $fillable = ['piggy_bank_id', 'transaction_journal_id', 'date', 'amount'];
+    protected $fillable = ['piggy_bank_id', 'transaction_journal_id', 'date', 'amount', 'transfer', 'account_id', 'from_account_id'];
     /** @var array Hidden from view */
     protected $hidden = ['amount_encrypted'];
 

--- a/app/Models/PiggyBankEvent.php
+++ b/app/Models/PiggyBankEvent.php
@@ -69,6 +69,24 @@ class PiggyBankEvent extends Model
 
     /**
      * @codeCoverageIgnore
+     * @return BelongsTo
+     */
+    public function account(): BelongsTo
+    {
+        return $this->belongsTo(Account::class);
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @return BelongsTo
+     */
+    public function from(): BelongsTo
+    {
+        return $this->belongsTo(Account::class, 'from_account_id');
+    }
+
+    /**
+     * @codeCoverageIgnore
      *
      * @param $value
      */

--- a/app/Repositories/PiggyBank/PiggyBankRepository.php
+++ b/app/Repositories/PiggyBank/PiggyBankRepository.php
@@ -171,8 +171,7 @@ class PiggyBankRepository implements PiggyBankRepositoryInterface
                     'piggy_bank_id' => $piggyBank->id,
                     'transaction_journal_id' => $journal->id,
                     'date' => $journal->date->format('Y-m-d'),
-                    'amount' => 0,
-                    'transfer' => $amount,
+                    'amount' => $amount,
                     'account_id' => $journal->transactions[1]->account_id,
                     'from_account_id' => $journal->transactions[0]->account_id,
                 ]

--- a/app/Repositories/PiggyBank/PiggyBankRepository.php
+++ b/app/Repositories/PiggyBank/PiggyBankRepository.php
@@ -150,7 +150,7 @@ class PiggyBankRepository implements PiggyBankRepositoryInterface
     public function createEvent(PiggyBank $piggyBank, string $amount): PiggyBankEvent
     {
         /** @var PiggyBankEvent $event */
-        $event = PiggyBankEvent::create(['date' => Carbon::now(), 'amount' => $amount, 'piggy_bank_id' => $piggyBank->id]);
+        $event = PiggyBankEvent::create(['date' => Carbon::now(), 'amount' => $amount, 'piggy_bank_id' => $piggyBank->id, 'account_id' => $piggyBank->account_id]);
 
         return $event;
     }

--- a/app/Repositories/PiggyBank/PiggyBankRepository.php
+++ b/app/Repositories/PiggyBank/PiggyBankRepository.php
@@ -164,6 +164,7 @@ class PiggyBankRepository implements PiggyBankRepositoryInterface
      */
     public function createEventWithJournal(PiggyBank $piggyBank, string $amount, TransactionJournal $journal): PiggyBankEvent
     {
+        //TODO:
         /** @var PiggyBankEvent $event */
         $event = PiggyBankEvent::create(
             [
@@ -171,6 +172,10 @@ class PiggyBankRepository implements PiggyBankRepositoryInterface
                 'transaction_journal_id' => $journal->id,
                 'date'                   => $journal->date->format('Y-m-d'),
                 'amount'                 => $amount]
+            //     'transfer'                 => $amount,
+            //     'account_id' => $piggyBank->account_id,
+            //     'from_account_id' => $piggyBank->account_id
+            // ]
         );
 
         return $event;

--- a/database/migrations/2019_02_24_092146_piggybank_enhancements.php
+++ b/database/migrations/2019_02_24_092146_piggybank_enhancements.php
@@ -13,25 +13,30 @@ class PiggybankEnhancements extends Migration
      */
     public function up()
     {
-        if (!Schema::hasTable('piggy_bank_accounts')) {
-            Schema::create(
-                'piggy_bank_accounts',
-                function (Blueprint $table) {
-                    $table->integer('piggy_bank_id', false, true);
-                    $table->integer('account_id', false, true);
-                    $table->foreign('piggy_bank_id')->references('id')->onUpdate('cascade')->on('piggy_banks')->onDelete('cascade');
-                    $table->foreign('account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
-                    $table->primary(['piggy_bank_id', 'account_id']);
-                }
-            );
-        }
+        // not really needed can track changes through new columns to events
+        // if (!Schema::hasTable('piggy_bank_accounts')) {
+        //     Schema::create(
+        //         'piggy_bank_accounts',
+        //         function (Blueprint $table) {
+        //             $table->integer('piggy_bank_id', false, true);
+        //             $table->integer('account_id', false, true);
+        //             $table->foreign('piggy_bank_id')->references('id')->onUpdate('cascade')->on('piggy_banks')->onDelete('cascade');
+        //             $table->foreign('account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
+        //             $table->primary(['piggy_bank_id', 'account_id']);
+        //         }
+        //     );
+        // }
 
-        Schema::table(
-            'piggy_bank_events',
+        Schema::table('piggy_bank_events',
             function (Blueprint $table) {
-                $table->integer('account_id', false, true)->after('piggy_bank_id')->nullable();;
+                // $table->decimal('transfer', 22, 12)->after('amount')->nullable();
+                $table->integer('account_id', false, true)->after('piggy_bank_id')->nullable();
+                $table->integer('from_account_id', false, true)->after('account_id')->nullable();
+                // $table->foreign('from_account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
             }
         );
+
+        // may need to do this statment per db type, e.g. mysql, sqlite, pgres
         DB::statement('
         UPDATE
                 piggy_bank_events t1,
@@ -39,8 +44,14 @@ class PiggybankEnhancements extends Migration
         SET
                 t1.account_id = t2.account_id
         WHERE
-                t1.piggy_bank_id = t2.id;'
-        );
+                t1.piggy_bank_id = t2.id;
+        ');
+
+        Schema::table('piggy_bank_events', function (Blueprint $table) {
+            $table->integer('account_id')->nullable(false)->change();
+            // $table->foreign('account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
+        });
+
         // DB::statement('ALTER TABLE `piggy_bank_events` MODIFY `age` DATETIME');
 
         // DB::statement('UPDATE `piggy_bank_events`
@@ -86,9 +97,11 @@ class PiggybankEnhancements extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('piggy_bank_accounts');
+        // Schema::dropIfExists('piggy_bank_accounts');
         Schema::table('piggy_bank_events', function (Blueprint $table) {
+            // $table->dropColumn(['transfer']);
             $table->dropColumn(['account_id']);
+            $table->dropColumn(['from_account_id']);
         });
     }
 }

--- a/database/migrations/2019_02_24_092146_piggybank_enhancements.php
+++ b/database/migrations/2019_02_24_092146_piggybank_enhancements.php
@@ -30,8 +30,8 @@ class PiggybankEnhancements extends Migration
         Schema::table('piggy_bank_events',
             function (Blueprint $table) {
                 // $table->decimal('transfer', 22, 12)->after('amount')->nullable();
-                $table->integer('account_id', false, true)->after('piggy_bank_id')->nullable();
-                $table->integer('from_account_id', false, true)->after('account_id')->nullable();
+                $table->unsignedInteger('account_id', false, true)->after('piggy_bank_id')->nullable();
+                $table->unsignedInteger('from_account_id', false, true)->after('account_id')->nullable();
                 $table->foreign('from_account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
             }
         );
@@ -48,8 +48,8 @@ class PiggybankEnhancements extends Migration
         ');
 
         Schema::table('piggy_bank_events', function (Blueprint $table) {
-            $table->integer('account_id')->nullable(false)->change();
-            // $table->foreign('account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
+            $table->unsignedInteger('account_id')->nullable(false)->change();
+            $table->foreign('account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
         });
 
         // DB::statement('ALTER TABLE `piggy_bank_events` MODIFY `age` DATETIME');
@@ -100,7 +100,7 @@ class PiggybankEnhancements extends Migration
         // Schema::dropIfExists('piggy_bank_accounts');
         Schema::table('piggy_bank_events', function (Blueprint $table) {
             // $table->dropColumn(['transfer']);
-            // $table->dropForeign('piggy_bank_events_account_id_foreign');
+            $table->dropForeign('piggy_bank_events_account_id_foreign');
             $table->dropColumn(['account_id']);
 
             $table->dropForeign('piggy_bank_events_from_account_id_foreign');

--- a/database/migrations/2019_02_24_092146_piggybank_enhancements.php
+++ b/database/migrations/2019_02_24_092146_piggybank_enhancements.php
@@ -29,7 +29,8 @@ class PiggybankEnhancements extends Migration
 
         Schema::table('piggy_bank_events',
             function (Blueprint $table) {
-                $table->decimal('transfer', 22, 12)->after('amount')->nullable();
+                // no longer needed can use isTransfer() function
+                // $table->decimal('transfer', 22, 12)->after('amount')->nullable();
                 $table->unsignedInteger('account_id', false, true)->after('piggy_bank_id')->nullable();
                 $table->unsignedInteger('from_account_id', false, true)->after('account_id')->nullable();
                 $table->foreign('from_account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
@@ -62,7 +63,7 @@ class PiggybankEnhancements extends Migration
     {
         // Schema::dropIfExists('piggy_bank_accounts');
         Schema::table('piggy_bank_events', function (Blueprint $table) {
-            $table->dropColumn(['transfer']);
+            // $table->dropColumn(['transfer']);
             $table->dropForeign('piggy_bank_events_account_id_foreign');
             $table->dropColumn(['account_id']);
 

--- a/database/migrations/2019_02_24_092146_piggybank_enhancements.php
+++ b/database/migrations/2019_02_24_092146_piggybank_enhancements.php
@@ -29,7 +29,7 @@ class PiggybankEnhancements extends Migration
 
         Schema::table('piggy_bank_events',
             function (Blueprint $table) {
-                // $table->decimal('transfer', 22, 12)->after('amount')->nullable();
+                $table->decimal('transfer', 22, 12)->after('amount')->nullable();
                 $table->unsignedInteger('account_id', false, true)->after('piggy_bank_id')->nullable();
                 $table->unsignedInteger('from_account_id', false, true)->after('account_id')->nullable();
                 $table->foreign('from_account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
@@ -99,7 +99,7 @@ class PiggybankEnhancements extends Migration
     {
         // Schema::dropIfExists('piggy_bank_accounts');
         Schema::table('piggy_bank_events', function (Blueprint $table) {
-            // $table->dropColumn(['transfer']);
+            $table->dropColumn(['transfer']);
             $table->dropForeign('piggy_bank_events_account_id_foreign');
             $table->dropColumn(['account_id']);
 

--- a/database/migrations/2019_02_24_092146_piggybank_enhancements.php
+++ b/database/migrations/2019_02_24_092146_piggybank_enhancements.php
@@ -51,43 +51,6 @@ class PiggybankEnhancements extends Migration
             $table->unsignedInteger('account_id')->nullable(false)->change();
             $table->foreign('account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
         });
-
-        // DB::statement('ALTER TABLE `piggy_bank_events` MODIFY `age` DATETIME');
-
-        // DB::statement('UPDATE `piggy_bank_events`
-        // SET
-        // `id` = <{id: }>,
-        // `created_at` = <{created_at: }>,
-        // `updated_at` = <{updated_at: }>,
-        // `piggy_bank_id` = <{piggy_bank_id: }>,
-        // `account_id` = <{account_id: }>,
-        // `transaction_journal_id` = <{transaction_journal_id: }>,
-        // `date` = <{date: }>,
-        // `amount` = <{amount: }>
-        // WHERE `id` = <{expr}>;
-        // SELECT * FROM fireflydev.piggy_bank_events;');
-
-        // setup composite keys
-        // $piggy_banks = DB::Select(DB::Raw('SELECT * FROM piggy_banks'));
-
-        //     DB::Statement('
-        //     INSERT INTO account (created_at, updated_at, name, project_id)
-        //     VALUES (NOW(), NOW(), "Migrated account", ' . $piggy_bank->account_id . ')
-        // ');
-        //     foreach ($piggy_banks as $piggy_bank) {
-        //         DB::Statement('
-        //     INSERT INTO account (created_at, updated_at, name, project_id)
-        //     VALUES (NOW(), NOW(), "Migrated account", ' . $project->project_id . ')
-        // ');
-        //     }
-        // update with id
-        // add foreign key
-        // Schema::table(
-        //     'piggy_bank_events',
-        //     function (Blueprint $table) {
-        //         $table->foreign('account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
-        //     }
-        // );
     }
 
     /**

--- a/database/migrations/2019_02_24_092146_piggybank_enhancements.php
+++ b/database/migrations/2019_02_24_092146_piggybank_enhancements.php
@@ -29,8 +29,6 @@ class PiggybankEnhancements extends Migration
 
         Schema::table('piggy_bank_events',
             function (Blueprint $table) {
-                // no longer needed can use isTransfer() function
-                // $table->decimal('transfer', 22, 12)->after('amount')->nullable();
                 $table->unsignedInteger('account_id', false, true)->after('piggy_bank_id')->nullable();
                 $table->unsignedInteger('from_account_id', false, true)->after('account_id')->nullable();
                 $table->foreign('from_account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
@@ -63,7 +61,6 @@ class PiggybankEnhancements extends Migration
     {
         // Schema::dropIfExists('piggy_bank_accounts');
         Schema::table('piggy_bank_events', function (Blueprint $table) {
-            // $table->dropColumn(['transfer']);
             $table->dropForeign('piggy_bank_events_account_id_foreign');
             $table->dropColumn(['account_id']);
 

--- a/database/migrations/2019_02_24_092146_piggybank_enhancements.php
+++ b/database/migrations/2019_02_24_092146_piggybank_enhancements.php
@@ -1,0 +1,94 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class PiggybankEnhancements extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!Schema::hasTable('piggy_bank_accounts')) {
+            Schema::create(
+                'piggy_bank_accounts',
+                function (Blueprint $table) {
+                    $table->integer('piggy_bank_id', false, true);
+                    $table->integer('account_id', false, true);
+                    $table->foreign('piggy_bank_id')->references('id')->onUpdate('cascade')->on('piggy_banks')->onDelete('cascade');
+                    $table->foreign('account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
+                    $table->primary(['piggy_bank_id', 'account_id']);
+                }
+            );
+        }
+
+        Schema::table(
+            'piggy_bank_events',
+            function (Blueprint $table) {
+                $table->integer('account_id', false, true)->after('piggy_bank_id')->nullable();;
+            }
+        );
+        DB::statement('
+        UPDATE
+                piggy_bank_events t1,
+                piggy_banks t2
+        SET
+                t1.account_id = t2.account_id
+        WHERE
+                t1.piggy_bank_id = t2.id;'
+        );
+        // DB::statement('ALTER TABLE `piggy_bank_events` MODIFY `age` DATETIME');
+
+        // DB::statement('UPDATE `piggy_bank_events`
+        // SET
+        // `id` = <{id: }>,
+        // `created_at` = <{created_at: }>,
+        // `updated_at` = <{updated_at: }>,
+        // `piggy_bank_id` = <{piggy_bank_id: }>,
+        // `account_id` = <{account_id: }>,
+        // `transaction_journal_id` = <{transaction_journal_id: }>,
+        // `date` = <{date: }>,
+        // `amount` = <{amount: }>
+        // WHERE `id` = <{expr}>;
+        // SELECT * FROM fireflydev.piggy_bank_events;');
+
+        // setup composite keys
+        // $piggy_banks = DB::Select(DB::Raw('SELECT * FROM piggy_banks'));
+
+        //     DB::Statement('
+        //     INSERT INTO account (created_at, updated_at, name, project_id)
+        //     VALUES (NOW(), NOW(), "Migrated account", ' . $piggy_bank->account_id . ')
+        // ');
+        //     foreach ($piggy_banks as $piggy_bank) {
+        //         DB::Statement('
+        //     INSERT INTO account (created_at, updated_at, name, project_id)
+        //     VALUES (NOW(), NOW(), "Migrated account", ' . $project->project_id . ')
+        // ');
+        //     }
+        // update with id
+        // add foreign key
+        // Schema::table(
+        //     'piggy_bank_events',
+        //     function (Blueprint $table) {
+        //         $table->foreign('account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
+        //     }
+        // );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('piggy_bank_accounts');
+        Schema::table('piggy_bank_events', function (Blueprint $table) {
+            $table->dropColumn(['account_id']);
+        });
+    }
+}

--- a/database/migrations/2019_02_24_092146_piggybank_enhancements.php
+++ b/database/migrations/2019_02_24_092146_piggybank_enhancements.php
@@ -32,7 +32,7 @@ class PiggybankEnhancements extends Migration
                 // $table->decimal('transfer', 22, 12)->after('amount')->nullable();
                 $table->integer('account_id', false, true)->after('piggy_bank_id')->nullable();
                 $table->integer('from_account_id', false, true)->after('account_id')->nullable();
-                // $table->foreign('from_account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
+                $table->foreign('from_account_id')->references('id')->onUpdate('cascade')->on('accounts')->onDelete('cascade');
             }
         );
 
@@ -100,7 +100,10 @@ class PiggybankEnhancements extends Migration
         // Schema::dropIfExists('piggy_bank_accounts');
         Schema::table('piggy_bank_events', function (Blueprint $table) {
             // $table->dropColumn(['transfer']);
+            // $table->dropForeign('piggy_bank_events_account_id_foreign');
             $table->dropColumn(['account_id']);
+
+            $table->dropForeign('piggy_bank_events_from_account_id_foreign');
             $table->dropColumn(['from_account_id']);
         });
     }

--- a/resources/views/v1/accounts/show.twig
+++ b/resources/views/v1/accounts/show.twig
@@ -138,6 +138,36 @@
             </div>
         {% endif %}
     </div>
+    <div class="row">
+        <div class="{% if periods.count > 0 %}col-lg-10 col-md-8 col-sm-12{% else %}col-lg-12 col-md-12 col-sm-12{% endif %}">
+            <div class="box">
+                <div class="box-header with-border">
+                    <h3 class="box-title">{{ 'piggy_banks'|_ }}</h3>
+                </div>
+                <div class="box-body table-responsive no-padding" id="piggyBanks">
+                    <table class="table table-hover">
+                        <tr>
+                            <th>{{ 'piggy_bank'|_ }}</th>
+                            <th>
+                                {{ trans('list.amount') }}
+                            </th>
+                        </tr>
+                        {% for piggy in account.piggyBankSummaries %}
+                            <tr>
+                                <td> 
+                                    <a href="{{ route('piggy-banks.show', piggy.piggy_bank_id) }}">{{ piggy.name }}</a>
+                                </td>
+                                <td class="account_amount">
+                                        {{piggy.Total - piggy.Transfers}}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+
+                </div>
+            </div>
+        </div>
+    </div>
 
 
 

--- a/resources/views/v1/list/piggy-bank-events.twig
+++ b/resources/views/v1/list/piggy-bank-events.twig
@@ -9,7 +9,7 @@
         <th>{{ trans('list.source_account') }}</th>
     </tr>
     {% for event in events %}
-        <tr data-name="{{ event.account_id }} {{ event.from_account_id }}">
+        <tr>
             {% if showPiggyBank %}
                 <td>
                     <a href="{{ route('piggy-banks.show',event.piggyBank.id) }}">{{ event.piggyBank.name }}</a>

--- a/resources/views/v1/list/piggy-bank-events.twig
+++ b/resources/views/v1/list/piggy-bank-events.twig
@@ -27,7 +27,7 @@
             <td style="text-align: right;">
 
                 {% if event.transfer > 0 %}
-                    <span class="text-info">{{ trans('firefly.transferred', {amount: formatAmountByAccount(event.piggyBank.account, event.transfer, false)})|raw }} {{formatAmountByAccount(event.piggyBank.account, event.transfer, false)}}</span>
+                    <span class="text-info">{{ trans('firefly.transferred')|raw }} {{formatAmountByAccount(event.piggyBank.account, event.transfer, false)}}</span>
                 {% elseif event.amount < 0 %}
                     <span class="text-danger">{{ trans('firefly.removed_amount', {amount: formatAmountByAccount(event.piggyBank.account, event.amount, false)})|raw }}</span>
                 {% else %}

--- a/resources/views/v1/list/piggy-bank-events.twig
+++ b/resources/views/v1/list/piggy-bank-events.twig
@@ -25,9 +25,9 @@
             </td>
 
             <td style="text-align: right;">
-
-                {% if event.transfer > 0 %}
-                    <span class="text-info">{{ trans('firefly.transferred')|raw }} {{formatAmountByAccount(event.piggyBank.account, event.transfer, false)}}</span>
+                
+                {% if event.transactionJournal.isTransfer() %}
+                    <span class="text-info">{{ trans('firefly.transferred')|raw }} {{formatAmountByAccount(event.piggyBank.account, event.amount, false)}}</span>
                 {% elseif event.amount < 0 %}
                     <span class="text-danger">{{ trans('firefly.removed_amount', {amount: formatAmountByAccount(event.piggyBank.account, event.amount, false)})|raw }}</span>
                 {% else %}

--- a/resources/views/v1/list/piggy-bank-events.twig
+++ b/resources/views/v1/list/piggy-bank-events.twig
@@ -5,9 +5,11 @@
         {% endif %}
         <th>{{ trans('list.date') }}</th>
         <th>{{ trans('list.amount') }}</th>
+        <th>{{ 'account'|_ }}</th>
+        <th>{{ trans('list.source_account') }}</th>
     </tr>
     {% for event in events %}
-        <tr>
+        <tr data-name="{{ event.account_id }} {{ event.from_account_id }}">
             {% if showPiggyBank %}
                 <td>
                     <a href="{{ route('piggy-banks.show',event.piggyBank.id) }}">{{ event.piggyBank.name }}</a>
@@ -24,10 +26,20 @@
 
             <td style="text-align: right;">
 
-                {% if event.amount < 0 %}
+                {% if event.transfer > 0 %}
+                    <span class="text-info">{{ trans('firefly.transferred', {amount: formatAmountByAccount(event.piggyBank.account, event.transfer, false)})|raw }} {{formatAmountByAccount(event.piggyBank.account, event.transfer, false)}}</span>
+                {% elseif event.amount < 0 %}
                     <span class="text-danger">{{ trans('firefly.removed_amount', {amount: formatAmountByAccount(event.piggyBank.account, event.amount, false)})|raw }}</span>
                 {% else %}
                     <span class="text-success">{{ trans('firefly.added_amount', {amount: formatAmountByAccount(event.piggyBank.account, event.amount, false)})|raw }}</span>
+                {% endif %}
+            </td>
+            <td> 
+                <a href="{{ route('accounts.show', event.account_id) }}">{{ event.account.name }}</a>
+            </td>
+            <td >
+                {% if event.from_account_id %}
+                    <a href="{{ route('accounts.show', event.from_account_id) }}">{{ event.from.name }}</a>
                 {% endif %}
             </td>
         </tr>

--- a/resources/views/v1/piggy-banks/show.twig
+++ b/resources/views/v1/piggy-banks/show.twig
@@ -90,6 +90,30 @@
             </div>
             <div class="box">
                 <div class="box-header with-border">
+                    <h3 class="box-title">{{ 'accounts'|_ }}</h3>
+                </div>
+                <div class="box-body table-responsive no-padding" id="piggyAccounts">
+                    <table class="table table-hover">
+                        <tr>
+                            <th>{{ 'account'|_ }}</th>
+                            <th>{{ trans('list.amount') }}</th>
+                        </tr>
+                        {% for account in piggyBank.accounts %}
+                            <tr>
+                                <td> 
+                                    <a href="{{ route('accounts.show', account.id) }}">{{ account.name }}</a>
+                                </td>
+                                <td style="text-align: right;">
+                                    {{formatAmountByAccount(piggyBank.account, account.total, false)}}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+
+                </div>
+            </div>
+            <div class="box">
+                <div class="box-header with-border">
                     <h3 class="box-title">{{ 'transactions'|_ }}</h3>
                 </div>
                 <div class="box-body table-responsive no-padding" id="piggyEvents">

--- a/resources/views/v1/piggy-banks/show.twig
+++ b/resources/views/v1/piggy-banks/show.twig
@@ -40,20 +40,26 @@
                         </tr>
                         <tr>
                             <td>{{ 'target_amount'|_ }}</td>
-                            <td>
+                            <td id="target_amount">
                                 {{ formatAmountBySymbol(piggy.target_amount, piggy.currency_symbol, piggy.currency_decimal_places) }}
                             </td>
                         </tr>
                         <tr>
                             <td>{{ 'saved_so_far'|_ }}</td>
                             <td>
-                                {{ formatAmountBySymbol(piggy.current_amount, piggy.currency_symbol, piggy.currency_decimal_places) }}
+                                <span id="saved_so_far">
+                                    {{ formatAmountBySymbol(piggy.current_amount, piggy.currency_symbol, piggy.currency_decimal_places) }}
+                                </span>
+                                <span id="currency_code">
+                                    {{piggy.currency_code}}
+                                </span>
                             </td>
                         </tr>
                         <tr>
                             <td>{{ 'left_to_save'|_ }}</td>
-                            <td>
-                                {{ formatAmountBySymbol(piggy.left_to_save, piggy.currency_symbol, piggy.currency_decimal_places) }}
+                                <span id="left_to_save">
+                                    {{ formatAmountBySymbol(piggy.left_to_save, piggy.currency_symbol, piggy.currency_decimal_places) }}
+                                </span>
                             </td>
                         </tr>
                         <tr>
@@ -61,7 +67,7 @@
                             <td>
                                 {% if piggyBank.startdate %}
                                     {{ piggyBank.startdate.formatLocalized(monthAndDayFormat) }}
-                                {% else %}
+                                    {% else %}
                                     <em>{{ 'no_start_date'|_ }}</em>
                                 {% endif %}
                             </td>
@@ -71,7 +77,7 @@
                             <td>
                                 {% if piggyBank.targetdate %}
                                     {{ piggyBank.targetdate.formatLocalized(monthAndDayFormat) }}
-                                {% else %}
+                                    {% else %}
                                     <em>{{ 'no_target_date'|_ }}</em>
                                 {% endif %}
                             </td>
@@ -97,14 +103,25 @@
                         <tr>
                             <th>{{ 'account'|_ }}</th>
                             <th>{{ trans('list.amount') }}</th>
+                            <th>
+                                {{ trans('list.amount') }}
+                            </th>
+                            <th>
+                                {{ trans('list.total_amount') }}
+                            </th>
                         </tr>
                         {% for account in piggyBank.accounts %}
                             <tr>
                                 <td> 
                                     <a href="{{ route('accounts.show', account.id) }}">{{ account.name }}</a>
                                 </td>
-                                <td style="text-align: right;">
-                                    {{formatAmountByAccount(piggyBank.account, account.sum + account.transfers - account.withdrawals, false)}}
+                                <td style="text-align: right;" class="account_code">
+                                    {{account.data}}
+                                </td>
+                                <td class="account_amount">
+                                        {{account.sum + account.transfers - account.withdrawals}}
+                                </td>
+                                <td style="text-align: right;" class="account_calculated">
                                 </td>
                             </tr>
                         {% endfor %}
@@ -123,7 +140,7 @@
         </div>
     </div>
 
-    {% if piggy.notes %}
+{% if piggy.notes %}
         <div class="row">
             <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
 
@@ -144,7 +161,7 @@
     <script type="text/javascript">
         var piggyBankID = {{ piggyBank.id }};
     </script>
-
+    
     <script type="text/javascript" src="v1/js/lib/Chart.bundle.min.js?v={{ FF_VERSION }}"></script>
     <script type="text/javascript" src="v1/js/ff/charts.defaults.js?v={{ FF_VERSION }}"></script>
     <script type="text/javascript" src="v1/js/ff/charts.js?v={{ FF_VERSION }}"></script>

--- a/resources/views/v1/piggy-banks/show.twig
+++ b/resources/views/v1/piggy-banks/show.twig
@@ -57,6 +57,7 @@
                         </tr>
                         <tr>
                             <td>{{ 'left_to_save'|_ }}</td>
+                            <td>
                                 <span id="left_to_save">
                                     {{ formatAmountBySymbol(piggy.left_to_save, piggy.currency_symbol, piggy.currency_decimal_places) }}
                                 </span>

--- a/resources/views/v1/piggy-banks/show.twig
+++ b/resources/views/v1/piggy-banks/show.twig
@@ -104,7 +104,7 @@
                                     <a href="{{ route('accounts.show', account.id) }}">{{ account.name }}</a>
                                 </td>
                                 <td style="text-align: right;">
-                                    {{formatAmountByAccount(piggyBank.account, account.total, false)}}
+                                    {{formatAmountByAccount(piggyBank.account, account.sum + account.transfers - account.withdrawals, false)}}
                                 </td>
                             </tr>
                         {% endfor %}

--- a/resources/views/v1/piggy-banks/show.twig
+++ b/resources/views/v1/piggy-banks/show.twig
@@ -120,7 +120,7 @@
                                     {{account.data}}
                                 </td>
                                 <td class="account_amount">
-                                        {{account.sum + account.transfers - account.withdrawals}}
+                                        {{account.sum - account.withdrawals}}
                                 </td>
                                 <td style="text-align: right;" class="account_calculated">
                                 </td>

--- a/resources/views/v1/transactions/single/create.twig
+++ b/resources/views/v1/transactions/single/create.twig
@@ -88,6 +88,7 @@
                         {{ ExpandedForm.text('tags') }}
 
                         {# RELATE THIS TRANSFER TO A PIGGY BANK #}
+                        {# no idea how to always show this, expanded form is not clear #}
                         <!-- C -->
                         {{ ExpandedForm.piggyBankList('piggy_bank_id', 0) }}
                         <!-- D -->


### PR DESCRIPTION
Fixes issue #1957 

an update on pull #2123. I know this will probably be rejected, until other priorities are done. I'm now using this b/c being able to organize piggy banks across multiple accounts is super useful for some things that I'm doing and I thought I'd show my changes.

You can rollback the db migrations safely before a new version update by doing 
`php artisan migrate:rollback --step=1` and just note how your accounts were organized

#### ignore these if you don't wish to have the multi currency account support
```
resources/views/v1/transactions/single/create.twig
public/v1/js/ff/piggy-banks/show.js
app/Http/Controllers/Chart/PiggyBankController.php
```

Changes in this pull request:

- allows piggy banks to support multiple accounts and currencies.
- adds transfer, account_id, from_account_id to piggy_bank_events table
  - also auto sets account_id to piggy bank default, db rollback works great (mysql only one tested)
- allows piggy banks to be used by multiple accounts
- didn't setup dropdown, but when adding or subtracting from piggy bank will use default account set to track
- shows total for each bank account in piggy bank display page (only for accounts that have had amounts added or subtracted, if have only been transferred from as source then the aggregation sql query won't include them)
  - sql aggregate query has been tested on **mysql** several times and calculates sum of each account for a piggy bank correctly, may need to be tweaked for postgres & sqlite.
- transfers only no longer change piggy bank current amount
- deposits and withdraws should now be supported, just need to update expandform to show on them (I could not figure this out)
-also displays  piggy bank amounts in accounts/show
- piggy bank total in the piggy-banks/show/ is calculated using currencies for each account

Account status amounts on page /piggy-banks still needs to be updated

@JC5
