### PR TITLE
Docker's entrypoint.sh: wait for DB before running DB-dependent artisan commands

### DIFF
--- a/.deploy/docker/entrypoint.sh
+++ b/.deploy/docker/entrypoint.sh
@@ -51,6 +51,18 @@ echo "Discover packages..."
 php artisan package:discover
 
 echo "Run various artisan commands..."
+. $FIREFLY_PATH/.env
+if [[ -z "$DB_PORT" ]]; then
+  if [[ $DB_CONNECTION == "pgsql" ]]; then
+    DB_PORT=5432
+  elif [[ $DB_CONNECTION == "mysql" ]]; then
+    DB_PORT=3306
+  fi
+fi
+if [[ ! -z "$DB_PORT" ]]; then
+  $FIREFLY_PATH/.deploy/docker/wait-for-it.sh "${DB_HOST}:${DB_PORT}" -- echo "db is up. Time to execute artisan commands"
+fi
+#env $(grep -v "^\#" .env | xargs) 
 php artisan migrate --seed
 php artisan firefly:decrypt-all
 php artisan firefly:upgrade-database

--- a/.deploy/docker/wait-for-it.sh
+++ b/.deploy/docker/wait-for-it.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        WAITFORIT_ISBUSY=1
+        WAITFORIT_BUSYTIMEFLAG="-t"
+
+else
+        WAITFORIT_ISBUSY=0
+        WAITFORIT_BUSYTIMEFLAG=""
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM php:7.2-apache
-
 ENV FIREFLY_PATH=/var/www/firefly-iii COMPOSER_ALLOW_SUPERUSER=1
 LABEL version="1.4" maintainer="thegrumpydictator@gmail.com"
 
 # Create volumes
 VOLUME $FIREFLY_PATH/storage/export $FIREFLY_PATH/storage/upload
 
-# Install some stuff
+# Install stuffs Firefly run & depends on: php extensions, locales, dev headers and composer
 RUN apt-get update && apt-get install -y libpng-dev \
                                             libicu-dev \
                                             unzip \
@@ -18,9 +17,28 @@ RUN apt-get update && apt-get install -y libpng-dev \
                                             apt-get clean && \
                                             rm -rf /var/lib/apt/lists/*
 
+RUN docker-php-ext-configure ldap --with-libdir=lib/$(gcc -dumpmachine)/ && \
+    docker-php-ext-install -j$(nproc) zip bcmath ldap gd pdo_pgsql pdo_mysql intl opcache && \
+    pecl install memcached-3.1.3 && \
+    docker-php-ext-enable memcached && \
+    a2enmod rewrite && a2enmod ssl && \
+    echo "de_DE.UTF-8 UTF-8\nen_US.UTF-8 UTF-8\nes_ES.UTF-8 UTF-8\nfr_FR.UTF-8 UTF-8\nid_ID.UTF-8 UTF-8\nit_IT.UTF-8 UTF-8\nnl_NL.UTF-8 UTF-8\npl_PL.UTF-8 UTF-8\npt_BR.UTF-8 UTF-8\nru_RU.UTF-8 UTF-8\ntr_TR.UTF-8 UTF-8\nzh_TW.UTF-8 UTF-8\nzh_CN.UTF-8 UTF-8\n\n" > /etc/locale.gen && \
+    locale-gen && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# configure PHP
+RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini && \
+    sed -i 's/max_execution_time = 30/max_execution_time = 600/' /usr/local/etc/php/php.ini && \
+    sed -i 's/memory_limit = 128M/memory_limit = 512M/' /usr/local/etc/php/php.ini
+
 # Copy in Firefly III source
 WORKDIR $FIREFLY_PATH
 ADD . $FIREFLY_PATH
+
+# Ensure correct app directory permission, then `composer install`
+RUN chown -R www-data:www-data /var/www && \
+    chmod -R 775 $FIREFLY_PATH/storage && \
+    composer install --prefer-dist --no-dev --no-scripts --no-suggest
 
 # copy ca certs to correct location
 COPY ./.deploy/docker/cacert.pem /usr/local/ssl/cert.pem
@@ -30,24 +48,6 @@ COPY ./.deploy/docker/apache2.conf /etc/apache2/apache2.conf
 
 # Enable default site (Firefly III)
 COPY ./.deploy/docker/apache-firefly.conf /etc/apache2/sites-available/000-default.conf
-
-# Run a lot of installation commands:
-RUN chown -R www-data:www-data /var/www && \
-    chmod -R 775 $FIREFLY_PATH/storage && \
-    a2enmod rewrite && a2enmod ssl && \
-    docker-php-ext-configure ldap --with-libdir=lib/$(gcc -dumpmachine)/ && \
-    docker-php-ext-install -j$(nproc) zip bcmath ldap gd pdo_pgsql pdo_mysql intl opcache && \
-    pecl install memcached-3.1.3 && \
-    docker-php-ext-enable memcached && \
-    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
-    echo "de_DE.UTF-8 UTF-8\nen_US.UTF-8 UTF-8\nes_ES.UTF-8 UTF-8\nfr_FR.UTF-8 UTF-8\nid_ID.UTF-8 UTF-8\nit_IT.UTF-8 UTF-8\nnl_NL.UTF-8 UTF-8\npl_PL.UTF-8 UTF-8\npt_BR.UTF-8 UTF-8\nru_RU.UTF-8 UTF-8\ntr_TR.UTF-8 UTF-8\nzh_TW.UTF-8 UTF-8\nzh_CN.UTF-8 UTF-8\n\n" > /etc/locale.gen && \
-    locale-gen && \
-    composer install --prefer-dist --no-dev --no-scripts --no-suggest
-
-# configure PHP
-RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini && \
-    sed -i 's/max_execution_time = 30/max_execution_time = 600/' /usr/local/etc/php/php.ini && \
-    sed -i 's/memory_limit = 128M/memory_limit = 512M/' /usr/local/etc/php/php.ini
 
 # Expose port 80
 EXPOSE 80

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -6,7 +6,7 @@ LABEL version="1.4" maintainer="thegrumpydictator@gmail.com"
 # Create volumes
 VOLUME $FIREFLY_PATH/storage/export $FIREFLY_PATH/storage/upload
 
-# Install some stuff
+# Install stuffs Firefly run & depends on: php extensions, locales, dev headers and composer
 RUN apt-get update && apt-get install -y libpng-dev \
                                             libicu-dev \
                                             unzip \
@@ -18,9 +18,28 @@ RUN apt-get update && apt-get install -y libpng-dev \
                                             apt-get clean && \
                                             rm -rf /var/lib/apt/lists/*
 
+RUN docker-php-ext-configure ldap --with-libdir=lib/$(gcc -dumpmachine)/ && \
+    docker-php-ext-install -j$(nproc) zip bcmath ldap gd pdo_pgsql pdo_mysql intl opcache && \
+    pecl install memcached-3.1.3 && \
+    docker-php-ext-enable memcached && \
+    a2enmod rewrite && a2enmod ssl && \
+    echo "de_DE.UTF-8 UTF-8\nen_US.UTF-8 UTF-8\nes_ES.UTF-8 UTF-8\nfr_FR.UTF-8 UTF-8\nid_ID.UTF-8 UTF-8\nit_IT.UTF-8 UTF-8\nnl_NL.UTF-8 UTF-8\npl_PL.UTF-8 UTF-8\npt_BR.UTF-8 UTF-8\nru_RU.UTF-8 UTF-8\ntr_TR.UTF-8 UTF-8\nzh_TW.UTF-8 UTF-8\nzh_CN.UTF-8 UTF-8\n\n" > /etc/locale.gen && \
+    locale-gen && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# configure PHP
+RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini && \
+    sed -i 's/max_execution_time = 30/max_execution_time = 600/' /usr/local/etc/php/php.ini && \
+    sed -i 's/memory_limit = 128M/memory_limit = 512M/' /usr/local/etc/php/php.ini
+
 # Copy in Firefly III source
 WORKDIR $FIREFLY_PATH
 ADD . $FIREFLY_PATH
+
+# Ensure correct app directory permission, then `composer install`
+RUN chown -R www-data:www-data /var/www && \
+    chmod -R 775 $FIREFLY_PATH/storage && \
+    composer install --prefer-dist --no-dev --no-scripts --no-suggest
 
 # copy ca certs to correct location
 COPY ./.deploy/docker/cacert.pem /usr/local/ssl/cert.pem
@@ -30,25 +49,6 @@ COPY ./.deploy/docker/apache2.conf /etc/apache2/apache2.conf
 
 # Enable default site (Firefly III)
 COPY ./.deploy/docker/apache-firefly.conf /etc/apache2/sites-available/000-default.conf
-
-# Run a lot of installation commands:
-RUN chown -R www-data:www-data /var/www && \
-    chmod -R 775 $FIREFLY_PATH/storage && \
-    a2enmod rewrite && a2enmod ssl && \
-    docker-php-ext-configure ldap --with-libdir=lib/$(gcc -dumpmachine)/ && \
-    docker-php-ext-install -j$(nproc) zip bcmath ldap gd pdo_pgsql pdo_mysql intl opcache && \
-    pecl install memcached-3.1.3 && \
-    docker-php-ext-enable memcached && \
-    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
-    echo "de_DE.UTF-8 UTF-8\nen_US.UTF-8 UTF-8\nes_ES.UTF-8 UTF-8\nfr_FR.UTF-8 UTF-8\nid_ID.UTF-8 UTF-8\nit_IT.UTF-8 UTF-8\nnl_NL.UTF-8 UTF-8\npl_PL.UTF-8 UTF-8\npt_BR.UTF-8 UTF-8\nru_RU.UTF-8 UTF-8\ntr_TR.UTF-8 UTF-8\nzh_TW.UTF-8 UTF-8\nzh_CN.UTF-8 UTF-8\n\n" > /etc/locale.gen && \
-    locale-gen && \
-    composer install --prefer-dist --no-dev --no-scripts --no-suggest
-
-# configure PHP
-RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini && \
-    sed -i 's/max_execution_time = 30/max_execution_time = 600/' /usr/local/etc/php/php.ini && \
-    sed -i 's/memory_limit = 128M/memory_limit = 512M/' /usr/local/etc/php/php.ini
-
 
 # Expose port 80
 EXPOSE 80

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,13 +1,12 @@
-FROM arm32v7/php:7.2.8-apache-stretch
+FROM php:7.2-apache
 ARG ARCH
-COPY tmp/qemu-arm-static /usr/bin/qemu-arm-static
 ENV FIREFLY_PATH=/var/www/firefly-iii COMPOSER_ALLOW_SUPERUSER=1
 LABEL version="1.4" maintainer="thegrumpydictator@gmail.com"
 
 # Create volumes
 VOLUME $FIREFLY_PATH/storage/export $FIREFLY_PATH/storage/upload
 
-# Install some stuff
+# Install stuffs Firefly run & depends on: php extensions, locales, dev headers and composer
 RUN apt-get update && apt-get install -y libpng-dev \
                                             libicu-dev \
                                             unzip \
@@ -15,11 +14,32 @@ RUN apt-get update && apt-get install -y libpng-dev \
                                             libldap2-dev \
                                             libpq-dev \
                                             locales \
-                                            libmemcached-dev
+                                            libmemcached-dev && \
+                                            apt-get clean && \
+                                            rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-configure ldap --with-libdir=lib/$(gcc -dumpmachine)/ && \
+    docker-php-ext-install -j$(nproc) zip bcmath ldap gd pdo_pgsql pdo_mysql intl opcache && \
+    pecl install memcached-3.1.3 && \
+    docker-php-ext-enable memcached && \
+    a2enmod rewrite && a2enmod ssl && \
+    echo "de_DE.UTF-8 UTF-8\nen_US.UTF-8 UTF-8\nes_ES.UTF-8 UTF-8\nfr_FR.UTF-8 UTF-8\nid_ID.UTF-8 UTF-8\nit_IT.UTF-8 UTF-8\nnl_NL.UTF-8 UTF-8\npl_PL.UTF-8 UTF-8\npt_BR.UTF-8 UTF-8\nru_RU.UTF-8 UTF-8\ntr_TR.UTF-8 UTF-8\nzh_TW.UTF-8 UTF-8\nzh_CN.UTF-8 UTF-8\n\n" > /etc/locale.gen && \
+    locale-gen && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# configure PHP
+RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini && \
+    sed -i 's/max_execution_time = 30/max_execution_time = 600/' /usr/local/etc/php/php.ini && \
+    sed -i 's/memory_limit = 128M/memory_limit = 512M/' /usr/local/etc/php/php.ini
 
 # Copy in Firefly III source
 WORKDIR $FIREFLY_PATH
 ADD . $FIREFLY_PATH
+
+# Ensure correct app directory permission, then `composer install`
+RUN chown -R www-data:www-data /var/www && \
+    chmod -R 775 $FIREFLY_PATH/storage && \
+    composer install --prefer-dist --no-dev --no-scripts --no-suggest
 
 # copy ca certs to correct location
 COPY ./.deploy/docker/cacert.pem /usr/local/ssl/cert.pem
@@ -29,19 +49,6 @@ COPY ./.deploy/docker/apache2.conf /etc/apache2/apache2.conf
 
 # Enable default site (Firefly III)
 COPY ./.deploy/docker/apache-firefly.conf /etc/apache2/sites-available/000-default.conf
-
-# Run a lot of installation commands:
-RUN chown -R www-data:www-data /var/www && \
-    chmod -R 775 $FIREFLY_PATH/storage && \
-    a2enmod rewrite && a2enmod ssl && \
-    docker-php-ext-configure ldap --with-libdir=lib/$(gcc -dumpmachine)/ && \
-    docker-php-ext-install -j$(nproc) zip bcmath ldap gd pdo_pgsql pdo_mysql intl opcache && \
-    pecl install memcached-3.1.3 && \
-    docker-php-ext-enable memcached && \
-    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
-    echo "de_DE.UTF-8 UTF-8\nen_US.UTF-8 UTF-8\nes_ES.UTF-8 UTF-8\nfr_FR.UTF-8 UTF-8\nid_ID.UTF-8 UTF-8\nit_IT.UTF-8 UTF-8\nnl_NL.UTF-8 UTF-8\npl_PL.UTF-8 UTF-8\npt_BR.UTF-8 UTF-8\nru_RU.UTF-8 UTF-8\ntr_TR.UTF-8 UTF-8\nzh_TW.UTF-8 UTF-8\nzh_CN.UTF-8 UTF-8\n\n" > /etc/locale.gen && \
-    locale-gen && \
-    composer install --prefer-dist --no-dev --no-scripts --no-suggest
 
 # Expose port 80
 EXPOSE 80

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,5 +1,6 @@
-FROM php:7.2-apache
+FROM arm32v7/php:7.2.8-apache-stretch
 ARG ARCH
+COPY tmp/qemu-arm-static /usr/bin/qemu-arm-static
 ENV FIREFLY_PATH=/var/www/firefly-iii COMPOSER_ALLOW_SUPERUSER=1
 LABEL version="1.4" maintainer="thegrumpydictator@gmail.com"
 


### PR DESCRIPTION
<!--
Before you create a new PR, please consider the following two considerations.

1) Pull request for the MASTER branch will be closed.
2) We cannot accept pull requests to add new currencies.

Thanks.
-->
(Sorry @JC5, accidentally added this pull request to the master branch just now. Hope you won't mind.)

Follow-up of #2122.

Changes in this pull request:

- Added [wait-for-it.sh](https://github.com/vishnubob/wait-for-it/)
- Used `wait-for-it.sh` to make sure DB is already up before running DB-dependent artisan commands
- Moved lengthy `docker-php-ext-install`s to top of `Dockerfile*`. Drastically improved build time while testing changes in `FIREFLY_PATH`

@JC5
