### PR TITLE
CSV file fix for Belfius

### DIFF
--- a/app/Import/Specifics/Belfius.php
+++ b/app/Import/Specifics/Belfius.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Belfius.php
+ * Copyright (c) 2019 Sander Kleykens <sander@kleykens.com>
+ *
+ * This file is part of Firefly III.
+ *
+ * Firefly III is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Firefly III is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Firefly III. If not, see <http://www.gnu.org/licenses/>.
+ */
+declare(strict_types=1);
+
+namespace FireflyIII\Import\Specifics;
+
+/**
+ * Class Belfius.
+ *
+ * Fixes Belfius CSV files to:
+ *  - Correct descriptions for recurring transactions so doubles can be detected when the equivalent incoming
+ *    transaction is imported.
+ *
+ */
+class Belfius implements SpecificInterface
+{
+    /**
+     * Description of this specific fix.
+     *
+     * @return string
+     * @codeCoverageIgnore
+     */
+    public static function getDescription(): string
+    {
+        return 'import.specific_belfius_descr';
+    }
+
+    /**
+     * Name of specific fix.
+     *
+     * @return string
+     * @codeCoverageIgnore
+     */
+    public static function getName(): string
+    {
+        return 'import.specific_belfius_name';
+    }
+
+    /**
+     * Run the fix.
+     *
+     * @param array $row
+     *
+     * @return array
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function run(array $row): array
+    {
+        return Belfius::processRecurringTransactionDescription($row);
+    }
+
+    /**
+     * Fixes the description for outgoing recurring transactions so doubles can be detected when the equivalent incoming
+     * transaction is imported for another bank account.
+     *
+     * @return array the row containing the new description
+     */
+    protected static function processRecurringTransactionDescription(array $row): array
+    {
+        if (!isset($row[5]) || !isset($row[14])) {
+            return $row;
+        }
+
+        $opposingAccountName = $row[5];
+        $description = $row[14];
+
+        preg_match('/DOORLOPENDE OPDRACHT.*\s+' . preg_quote($opposingAccountName, '/') . '\s+(.+)\s+REF.\s*:/', $description, $matches);
+
+        if (isset($matches[1])) {
+            $row[14] = $matches[1];
+        }
+
+        return $row;
+    }
+}

--- a/config/csv.php
+++ b/config/csv.php
@@ -26,6 +26,7 @@ use FireflyIII\Import\Specifics\AbnAmroDescription;
 use FireflyIII\Import\Specifics\IngDescription;
 use FireflyIII\Import\Specifics\PresidentsChoice;
 use FireflyIII\Import\Specifics\SnsDescription;
+use FireflyIII\Import\Specifics\Belfius;
 
 return [
 
@@ -37,6 +38,7 @@ return [
         'AbnAmroDescription' => AbnAmroDescription::class,
         'SnsDescription'     => SnsDescription::class,
         'PresidentsChoice'   => PresidentsChoice::class,
+        'Belfius'            => Belfius::class
     ],
 
     /*

--- a/resources/lang/en_US/import.php
+++ b/resources/lang/en_US/import.php
@@ -207,6 +207,8 @@ return [
     'specific_rabo_descr'             => 'Fixes potential problems with Rabobank files',
     'specific_pres_name'              => 'President\'s Choice Financial CA',
     'specific_pres_descr'             => 'Fixes potential problems with PC files',
+    'specific_belfius_name'           => 'Belfius BE',
+    'specific_belfius_descr'          => 'Fixes potential problems with Belfius files',
     // job configuration for file provider (stage: roles)
     'job_config_roles_title'          => 'Import setup (3/4) - Define each column\'s role',
     'job_config_roles_text'           => 'Each column in your CSV file contains certain data. Please indicate what kind of data the importer should expect. The option to "map" data means that you will link each entry found in the column to a value in your database. An often mapped column is the column that contains the IBAN of the opposing account. That can be easily matched to IBAN\'s present in your database already.',

--- a/tests/Unit/Import/Specifics/BelfiusTest.php
+++ b/tests/Unit/Import/Specifics/BelfiusTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * BelfiusTest.php
+ * Copyright (c) 2019 Sander Kleykens <sander@kleykens.com>
+ *
+ * This file is part of Firefly III.
+ *
+ * Firefly III is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Firefly III is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Firefly III. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Import\Specifics;
+
+
+use FireflyIII\Import\Specifics\Belfius;
+use Tests\TestCase;
+use Log;
+
+/**
+ * Class BelfiusTest
+ */
+class BelfiusTest extends TestCase
+{
+    /**
+     *
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        Log::info(sprintf('Now in %s.', \get_class($this)));
+    }
+
+
+    /**
+     * Should return the exact same array.
+     *
+     * @covers \FireflyIII\Import\Specifics\Belfius
+     */
+    public function testEmptyRow(): void
+    {
+        $row = [1, 2, 3, 4];
+
+        $parser = new Belfius;
+        $result = $parser->run($row);
+        $this->assertEquals($row, $result);
+    }
+
+    /**
+     * Data that cannot be parsed.
+     *
+     * @covers \FireflyIII\Import\Specifics\Belfius
+     */
+    public function testProcessUnknown(): void
+    {
+        $row = [0, 1, 2, 3, 4, 'STORE BRUSSEL n/v', 6, 7, 8, 9, 10, 11, 12, 13, 'AANKOOP BANCONTACT CONTACTLESS MET KAART NR 01234 5678 9012 3456 - FOO BAR OP 01/01 00:01 STORE BRUSSEL n/v REF. :   01234567890 VAL. 01-01'];
+
+        $parser = new Belfius;
+        $result = $parser->run($row);
+        $this->assertEquals($row, $result);
+    }
+
+    /**
+     * Data with recurring transaction.
+     *
+     * @covers \FireflyIII\Import\Specifics\Belfius
+     */
+    public function testProcessRecurringTransaction(): void
+    {
+        $row = [0, 1, 2, 3, 4, 'Tom Jones', 6, 7, 8, 9, 10, 11, 12, 13, 'DOORLOPENDE OPDRACHT 12345678 NAAR BE01 1234 5678 9012 Tom Jones My Description REF. : 01234567890 VAL. 01-01'];
+
+        $parser = new Belfius;
+        $result = $parser->run($row);
+        $this->assertEquals('My Description', $result[14]);
+    }
+}


### PR DESCRIPTION
This pull request adds a CSV file fix option for Belfius Bank (Belgium). 

### Problem
Belfius CSV files have, among other columns, a column containing the transaction description ("mededeling") and a "transaction" column, containing a short summary of the transaction (which also includes, but is not limited to, the transaction description or "mededeling").
For outgoing recurring transactions, the "mededeling" column contains the same short summary of the transaction as the "transaction" column.
This causes problems when the outgoing recurring transaction is a recurring transaction to another account that gets imported as well. The transaction descriptions can't be matched since the "mededeling" column for the outgoing transaction contains more than just the transaction description, unlike the receiving account's transaction. This results in duplicate transactions being imported.

### Implementation
In the fix implemented by this pull request, the "transaction" column containing a short summary of the transaction remains as is. However, the transaction description ("mededeling") column of recurring transactions gets adjusted to only contain the transaction description ("mededeling"), so it matches the description found for the transaction at the receiving end.