### PR TITLE
Correct ratesapi URL

### DIFF
--- a/app/Services/Currency/RatesApiIOv1.php
+++ b/app/Services/Currency/RatesApiIOv1.php
@@ -71,7 +71,7 @@ class RatesApiIOv1 implements ExchangeRateInterface
 
         // build URI
         $uri = sprintf(
-            'https://ratesapi.io/api/%s?base=%s&symbols=%s',
+            'https://api.ratesapi.io/api/%s?base=%s&symbols=%s',
             $date->format('Y-m-d'), $fromCurrency->code, $toCurrency->code
         );
         Log::debug(sprintf('Going to request exchange rate using URI %s', $uri));


### PR DESCRIPTION
Changes in this pull request:

- Correct the endpoint for ratesapi. The current one returns 500, the new one works correctly.

@JC5
