### PR TITLE
Allow a custom redirect scheme (using redirect)

### DIFF
--- a/.deploy/docker/apache-firefly.conf
+++ b/.deploy/docker/apache-firefly.conf
@@ -11,6 +11,8 @@
 
         ErrorLog ${APACHE_LOG_DIR}/error.log
         CustomLog ${APACHE_LOG_DIR}/access.log combined
+        
+        Redirect permanent /oauth-callback org.firefly-iii://oauth-callback
 
     <Directory /var/www/firefly-iii/public>
         Options -Indexes +FollowSymLinks


### PR DESCRIPTION
This Apache config change will add support for a custom (OAuth2) redirect URL scheme. This can be used for e.g. mobile apps.

So, in Firefly OAuth config you can use `https://{your-domain}.com/oauth-callback` as a redirect/callback URL and in an (mobile) app register the custom scheme `org.firefly-iii`.

Please let me know what you think of this, it would help me with my iOS development.

@JC5
