### PR TITLE
Fix typo in BudgetRepository (emd_date)

### DIFF
--- a/app/Repositories/Budget/BudgetRepository.php
+++ b/app/Repositories/Budget/BudgetRepository.php
@@ -1069,7 +1069,7 @@ class BudgetRepository implements BudgetRepositoryInterface
             $query->where('start_date', '>=', $start->format('Y-m-d H:i:s'));
         }
         if (null !== $end) {
-            $query->where('emd_date', '<=', $end->format('Y-m-d H:i:s'));
+            $query->where('end_date', '<=', $end->format('Y-m-d H:i:s'));
         }
 
         return $query->get();


### PR DESCRIPTION
Changes in this pull request:

- Fixed typo in BudgetRepository which could trigger an SQL error during a GET `/api/v1/available_budgets` with the `end` parameter set. 

@JC5
