### PR TITLE
Fix consistency in symbol character limit

### DIFF
--- a/app/Api/V1/Requests/CurrencyRequest.php
+++ b/app/Api/V1/Requests/CurrencyRequest.php
@@ -80,7 +80,7 @@ class CurrencyRequest extends Request
         $rules = [
             'name'           => 'required|between:1,255|unique:transaction_currencies,name',
             'code'           => 'required|between:3,3|unique:transaction_currencies,code',
-            'symbol'         => 'required|between:1,5|unique:transaction_currencies,symbol',
+            'symbol'         => 'required|between:1,8|unique:transaction_currencies,symbol',
             'decimal_places' => 'between:0,20|numeric|min:0|max:20',
             'enabled'        => [new IsBoolean()],
             'default'        => [new IsBoolean()],
@@ -94,8 +94,8 @@ class CurrencyRequest extends Request
             case 'PATCH':
                 $currency        = $this->route()->parameter('currency_code');
                 $rules['name']   = 'required|between:1,255|unique:transaction_currencies,name,' . $currency->id;
-                $rules['code']   = 'required|between:1,255|unique:transaction_currencies,code,' . $currency->id;
-                $rules['symbol'] = 'required|between:1,255|unique:transaction_currencies,symbol,' . $currency->id;
+                $rules['code']   = 'required|between:3,3|unique:transaction_currencies,code,' . $currency->id;
+                $rules['symbol'] = 'required|between:1,8|unique:transaction_currencies,symbol,' . $currency->id;
                 break;
         }
 


### PR DESCRIPTION
Fixes issue #2441 

Changes in this pull request:

- Made the character limit for currencies consistent in the API with the GUI 

I swear I looked into the code to see if this was a fix I could do. I should look harder before filling an issue next time :sweat_smile:

However I noticed the rules for `decimal_places`, `enabled` and `default` are not there. Is this intentional (I don't know, some kind of inheritance maybe)?

@JC5
