### PR TITLE
Allow override of base URL

### DIFF
--- a/config/firefly.php
+++ b/config/firefly.php
@@ -140,6 +140,7 @@ return [
     'fixer_api_key'                => env('FIXER_API_KEY', ''),
     'mapbox_api_key'               => env('MAPBOX_API_KEY', ''),
     'trusted_proxies'              => env('TRUSTED_PROXIES', ''),
+    'baseurl_override'             => env('BASEURL_OVERRIDE', ''),
     'search_result_limit'          => env('SEARCH_RESULT_LIMIT', 50),
     'send_report_journals'         => envNonEmpty('SEND_REPORT_JOURNALS', true),
     'analytics_id'                 => env('ANALYTICS_ID', ''),

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,10 @@
 
 declare(strict_types=1);
 
+if ('' !== config('firefly.baseurl_override') {
+    URL::forceRootUrl(config('firefly.baseurl_override'));
+}
+
 Route::group(
     ['namespace' => 'FireflyIII\Http\Controllers\System',
      'as'        => 'installer.', 'prefix' => 'install'], function () {


### PR DESCRIPTION
Without this reverse proxying outside of the root of a domain requires unreliable workarounds (rewriting HTTP header and even content).


Fixes issue #1869 (and possibly others)

Changes in this pull request:

- Introduce environment variable configuration to optionally force root URL so correct routes are generated when the application is not at the root of a domain (e.g. example.com/firefly)

Without this, all routes are broken when the site is not running at the root path because the routes are produced as absolute URIs. In this situation, most or all redirects are broken and most or all asset references (CSS, JS, images) are broken.

@JC5