### PR TITLE
Fixed definition of Request->nullableNlString

### DIFF
--- a/app/Http/Requests/Request.php
+++ b/app/Http/Requests/Request.php
@@ -244,7 +244,7 @@ class Request extends FormRequest
      *
      * @return string
      */
-    public function nullableNlString(string $field): string
+    public function nullableNlString(string $field): ?string
     {
         if (!$this->has($field)) {
             return null;


### PR DESCRIPTION
Typo I introduced in f8cb5ca21c9a38666134966c59626c82be4a4eaf

<!--
Before you create a new PR, please consider the following two considerations.

1) Pull request for the MASTER branch will be closed.
2) We cannot accept pull requests to add new currencies.

Thanks.
-->

Fixes potential error: `Symfony\Component\Debug\Exception\FatalThrowableError: Return value of FireflyIII\Http\Requests\Request::nullableNlString() must be of the type string, null returned`

Changes in this pull request:

- Fixed definition of Request->nullableNlString

@JC5
