### PR TITLE
Suggestion for a dev environment docker-compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,55 @@
+---
+networks:
+  firefly_iii_net:
+    driver: bridge
+services:
+  firefly_iii_app:
+    environment:
+      - FF_DB_HOST=firefly_iii_db
+      - FF_DB_NAME=firefly
+      - FF_DB_USER=firefly
+      - FF_DB_PASSWORD=firefly
+      - FF_APP_KEY=ildwldR00sVU5kEbNQEPZIM8n5FryuyH
+      - FF_APP_ENV=local
+      - FF_DB_CONNECTION=pgsql
+      - TZ=Europe/Amsterdam
+      - APP_LOG_LEVEL=debug
+    #image: jc5x/firefly-iii
+    build:
+      context: .
+    links:
+      - firefly_iii_db
+    networks:
+      - firefly_iii_net
+    ports:
+      - "80:80"
+    volumes:
+      -
+        source: .
+        target: /var/www/firefly-iii
+        type: bind
+      -
+        source: firefly_iii_export
+        target: /var/www/firefly-iii/storage/export
+        type: volume
+      -
+        source: firefly_iii_upload
+        target: /var/www/firefly-iii/storage/upload
+        type: volume
+  firefly_iii_db:
+    environment:
+      - POSTGRES_PASSWORD=firefly
+      - POSTGRES_USER=firefly
+    image: "postgres:10"
+    networks:
+      - firefly_iii_net
+    ports:
+      - "5432:5432"
+    volumes:
+      - "firefly_iii_db:/var/lib/postgresql/data"
+version: "3.2"
+volumes:
+  firefly_iii_db: ~
+  firefly_iii_export: ~
+  firefly_iii_upload: ~
+  firefly_iii_src: ~


### PR DESCRIPTION
<!--
Before you create a new PR, please consider the following two considerations.

1) Pull request for the MASTER branch will be closed.
2) We cannot accept pull requests to add new currencies.

Thanks.
-->

Changes in this pull request:

- This PR suggests a slightly changed `docker-compose.yml` with the new name `docker-compose.dev.yml` for development environments as an alternative: instead pulling an image, it binds the current source directory. It opens the port of the container's database so it can be accessed with external tools, CLI or GUI. 

I decided to create a parallel file because documentation suggests that `docker-compose.yml` is the key file to create self-hosted containers. It therefore would need to be used explicitly in the `docker-compose` command.

`docker-compose run -f ./docker-compose.dev.yml`

@JC5
