### PR TITLE
Fixed Category section having no chart in Dashboard (#2796)

### DIFF
--- a/app/Http/Controllers/Chart/CategoryController.php
+++ b/app/Http/Controllers/Chart/CategoryController.php
@@ -163,18 +163,18 @@ class CategoryController extends Controller
         $noCategory = $noCatRepository->sumExpenses($start, $end);
 
         foreach ($noCategory as $currency) {
-            $currencyId              = $currency['currency_id'];
+            $currencyId              = (int)$currency['currency_id'];
             $currencies[$currencyId] = $currencies[$currencyId] ?? [
                     'currency_id'             => $currency['currency_id'],
                     'currency_name'           => $currency['currency_name'],
                     'currency_symbol'         => $currency['currency_symbol'],
                     'currency_code'           => $currency['currency_code'],
-                    'currency_decimal_places' => $currency['currency_decimal_places'],
+                    'currency_decimal_places' => (int)$currency['currency_decimal_places'],
                 ];
             $tempData[]              = [
                 'name'        => trans('firefly.no_category'),
                 'sum'         => $currency['sum'],
-                'sum_float'   => round($currency['sum'], $currency['currency_decimal_places']),
+                'sum_float'   => round($currency['sum'], (int)$currency['currency_decimal_places']),
                 'currency_id' => $currency['currency_id'],
             ];
         }

--- a/app/Support/Chart/Category/WholePeriodChartGenerator.php
+++ b/app/Support/Chart/Category/WholePeriodChartGenerator.php
@@ -174,7 +174,7 @@ class WholePeriodChartGenerator
                         'currency_name'           => $currencyRow['currency_name'],
                         'currency_symbol'         => $currencyRow['currency_symbol'],
                         'currency_code'           => $currencyRow['currency_code'],
-                        'currency_decimal_places' => $currencyRow['currency_decimal_places'],
+                        'currency_decimal_places' => (int)$currencyRow['currency_decimal_places'],
                     ];
             }
         }


### PR DESCRIPTION
<!--
Before you create a new PR, please consider the following two considerations.

1) Pull request for the MASTER branch will be closed.
2) We cannot accept pull requests to add new currencies.

Thanks.
-->

Fixes issue #2796

Changes in this pull request:

- Added `(int)` in lines 166, 172 and 177 in `CategoryController.php` and line 177 in `WholePeriodChartGenerator.php` to suppress error `round() expects parameter 2 to be int, string given`


@JC5
