### PR TITLE
Fix account endpoint in create-edit.js

### DIFF
--- a/public/v1/js/ff/rules/create-edit.js
+++ b/public/v1/js/ff/rules/create-edit.js
@@ -252,11 +252,11 @@ function updateActionInput(selectList) {
             break;
         case 'set_source_account':
             console.log('Select list value is ' + selectList.val() + ', so input needs auto complete.');
-            createAutoComplete(inputResult, 'json/all-accounts');
+            createAutoComplete(inputResult, 'json/accounts');
             break;
         case 'set_destination_account':
             console.log('Select list value is ' + selectList.val() + ', so input needs auto complete.');
-            createAutoComplete(inputResult, 'json/all-accounts');
+            createAutoComplete(inputResult, 'json/accounts');
             break;
         case 'convert_withdrawal':
             console.log('Select list value is ' + selectList.val() + ', so input needs expense accounts auto complete.');


### PR DESCRIPTION
Changes in this pull request:

-    change the endpoint for creating/editing rules to the correct one

This issue affects also current stable release.

@JC5

This should be a legitimate pull.

Also a warning: all "convert" select list suffers from the same problem, but i can't find a way to create an autocomplete for accounts filtered by type.

`createAutoComplete(inputResult, 'json/accounts?type=revenue');` does not works.

A temporary workaround should be `createAutoComplete(inputResult, 'json/accounts');`  but does not filter the account type.