### PR TITLE
Add Debit to Generic Debit Credit indicator converter

### DIFF
--- a/app/Import/Converter/BankDebitCredit.php
+++ b/app/Import/Converter/BankDebitCredit.php
@@ -50,6 +50,7 @@ class BankDebitCredit implements ConverterInterface
             'Af', // ING (NL).
             'Debet', // Triodos (NL)
             'S', // "Soll", German term for debit
+            'Debit', // Community America (US)
         ];
         if (in_array(trim($value), $negative, true)) {
             return -1;


### PR DESCRIPTION
Example CSV export from Community America, a Credit Union in the US:

``` csv
12/11/19,Five Guys,Sale FIVE GUYS,14.51,Debit,Food & Dining,Fast Food,CC1,,,false
12/11/19,Interest Income,Interest Earned,0.01,Credit,Income,Interest Income,Regular Savings,,Interest Earned,false
```

"Debit" is used in the type column instead of negative values in the amount column.

Fixes issue # (if relevant): None created

Changes in this pull request:

- Adds "Debit" to list of generic debit/credit terms


@JC5
