### PR TITLE
Change a newly-deprecated array access

### DIFF
--- a/app/Support/Import/Routine/File/ImportableConverter.php
+++ b/app/Support/Import/Routine/File/ImportableConverter.php
@@ -142,7 +142,7 @@ class ImportableConverter
             try {
                 // add exclamation mark for better parsing. http://php.net/manual/en/datetime.createfromformat.php
                 $dateFormat = $this->config['date-format'] ?? 'Ymd';
-                if ('!' !== $dateFormat{0}) {
+                if ('!' !== $dateFormat[0]) {
                     $dateFormat = '!' . $dateFormat;
                 }
                 $object = Carbon::createFromFormat($dateFormat, $date);


### PR DESCRIPTION
PHP allowed array accesses with curly braces but [deprecated the feature](https://wiki.php.net/rfc/deprecate_curly_braces_array_access) with 7.4. With this change the CSV import will work on 7.4 without any errors or warnings. The change does not affect other versions.

Side node: everything else I tested seems to work well with 7.4.1.