### PR TITLE
Locale on Windows

### DIFF
--- a/app/Http/Middleware/Range.php
+++ b/app/Http/Middleware/Range.php
@@ -77,8 +77,14 @@ class Range
         $lang = $pref->data;
         App::setLocale($lang);
         Carbon::setLocale(substr($lang, 0, 2));
-        $locale = explode(',', (string)trans('config.locale'));
-        $locale = array_map('trim', $locale);
+
+        // On Windows, setlocale(LC_ALL, '') sets the locale names from the system's regional/language settings
+        if (PHP_OS_FAMILY === 'Windows') {
+            $locale = '';
+        } else {
+            $locale = explode(',', (string)trans('config.locale'));
+            $locale = array_map('trim', $locale);
+        }
 
         setlocale(LC_TIME, $locale);
         $moneyResult = setlocale(LC_MONETARY, $locale);


### PR DESCRIPTION
Changes in this pull request:

- Fixed currency locale on Windows

On Windows, setlocale(LC_ALL, '') sets the locale names from the system's regional/language settings