### PR TITLE
API: Unified attachment_* and model_* for Attachments

### DIFF
--- a/app/Api/V1/Requests/AttachmentStoreRequest.php
+++ b/app/Api/V1/Requests/AttachmentStoreRequest.php
@@ -57,8 +57,8 @@ class AttachmentStoreRequest extends Request
             'filename' => $this->string('filename'),
             'title'    => $this->string('title'),
             'notes'    => $this->nlString('notes'),
-            'model'    => $this->string('model'),
-            'model_id' => $this->integer('model_id'),
+            'model'    => $this->string('attachable_type'),
+            'model_id' => $this->integer('attachable_id'),
         ];
     }
 
@@ -77,14 +77,14 @@ class AttachmentStoreRequest extends Request
                 str_replace('FireflyIII\\Models\\', '', TransactionJournal::class),
             ]
         );
-        $model  = $this->string('model');
+        $model  = $this->string('attachable_type');
 
         return [
-            'filename' => 'required|between:1,255',
-            'title'    => 'between:1,255',
-            'notes'    => 'between:1,65000',
-            'model'    => sprintf('required|in:%s', $models),
-            'model_id' => ['required', 'numeric', new IsValidAttachmentModel($model)],
+            'filename'        => 'required|between:1,255',
+            'title'           => 'between:1,255',
+            'notes'           => 'between:1,65000',
+            'attachable_type' => sprintf('required|in:%s', $models),
+            'attachable_id'   => ['required', 'numeric', new IsValidAttachmentModel($model)],
         ];
     }
 }

--- a/app/Api/V1/Requests/AttachmentUpdateRequest.php
+++ b/app/Api/V1/Requests/AttachmentUpdateRequest.php
@@ -52,8 +52,8 @@ class AttachmentUpdateRequest extends Request
             'filename' => $this->string('filename'),
             'title'    => $this->string('title'),
             'notes'    => $this->nlString('notes'),
-            'model'    => $this->string('model'),
-            'model_id' => $this->integer('model_id'),
+            'model'    => $this->string('attachable_type'),
+            'model_id' => $this->integer('attachable_id'),
         ];
     }
 


### PR DESCRIPTION
Currently when creating/updating an Attachment, we need to use the fields `model` and `model_id` to specify the object the attachment refers to. However to read the same values back from the API the names are `attachable_type` and `attachble_id`.

This PR fixes this inconsistency. I choose to roll with `attachable` rather than `model` because it makes more sense and (probably) requires the least changes, even though it creates an inconsistency with the DB table.