### PR TITLE
Move redis comment to different line

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,8 @@ SESSION_DRIVER=file
 REDIS_HOST=127.0.0.1
 REDIS_PASSWORD=null
 REDIS_PORT=6379
-REDIS_DB="0" # always use quotes
+# always use quotes and make sure redis db "0" and "1" exists. Otherwise change accordingly.
+REDIS_DB="0"
 REDIS_CACHE_DB="1"
 
 # Cookie settings. Should not be necessary to change these.


### PR DESCRIPTION


Fixes issue #3091 

Changes in this pull request:
Move comment about quotes in redis db index to own line. The comment in the variable caused redis to use `"0" #always use quotes` as redis db index instead of just `"0"`.