### PR TITLE
Fix search modifiers claiming the whole query

### DIFF
--- a/app/Support/Search/Search.php
+++ b/app/Support/Search/Search.php
@@ -123,7 +123,7 @@ class Search implements SearchInterface
     {
         $filteredQuery       = app('steam')->cleanString($query);
         $this->originalQuery = $filteredQuery;
-        $pattern             = '/[[:alpha:]_]*:"?[\P{C}_-]*"?/ui';
+        $pattern             = '/[[:alpha:]_]*:(".*"|[\P{Zs}_-]*)/ui';
         $matches             = [];
         preg_match_all($pattern, $filteredQuery, $matches);
 


### PR DESCRIPTION
The regex being used to detect search modifiers was only restricted to characters without the Unicode property Other, which is most characters, including spaces. That meant that almost anything following a modifier got treated as part of it, breaking, among other things, combining modifiers. This version will include anything but a space, unless the value is quoted, in which case it'll accept anything.

### Old regex:
![Screen Shot 2020-02-17 at 20 25 56](https://user-images.githubusercontent.com/9437625/74696431-816c7f80-51c5-11ea-961b-aeb61df55dd1.png)

### New regex:
![Screen Shot 2020-02-17 at 20 27 41](https://user-images.githubusercontent.com/9437625/74696445-8cbfab00-51c5-11ea-9f3a-403e697838c4.png)
