### PR TITLE
add 2 <th> to fix header row border, fix alignment on action btn

### DIFF
--- a/resources/views/v1/list/groups.twig
+++ b/resources/views/v1/list/groups.twig
@@ -29,6 +29,8 @@ TODO: hide and show columns
         {% if showBudget %}
             <th>{{ trans('list.budget') }}</th>
         {% endif %}
+        <th>&nbsp;</th>
+        <th>&nbsp;</th>
     </tr>
     </thead>
     <tbody>
@@ -174,7 +176,7 @@ TODO: hide and show columns
 
                 {% if group.count == 1 %}
                     <td style=" {{ style|raw }};">
-                        <div class="btn-group btn-group-xs">
+                        <div class="btn-group btn-group-xs pull-right">
                             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 {{ 'actions'|_ }} <span class="caret"></span></button>
                             <ul class="dropdown-menu dropdown-menu-right" role="menu">


### PR DESCRIPTION
Changes in this pull request:
- Bottom border on transactions list header did not continue the whole way, a couple of column headers were missing
- action buttons were aligned differently for single and split transactions.

**Before:**
![Firefly-Before-Annotated](https://user-images.githubusercontent.com/1606549/74997438-166cb400-5424-11ea-8b03-956d216cc558.jpg)
**After:**
![Firefly-After](https://user-images.githubusercontent.com/1606549/74997455-1f5d8580-5424-11ea-995f-a27fbf933f95.jpg)

@JC5 didn't discuss first hope that's ok.