### PR TITLE
Better CSV import for ING (NL)

### DIFF
--- a/app/Import/Specifics/IngDescription.php
+++ b/app/Import/Specifics/IngDescription.php
@@ -114,7 +114,7 @@ class IngDescription implements SpecificInterface
      */
     protected function removeIBANIngDescription(): void
     {
-        // Try replace the iban number with nothing. The IBAN nr is found in the third row
+        // Try replace the iban number with nothing. The IBAN nr is found in the third column
         $this->row[8] = preg_replace('/\sIBAN:\s' . $this->row[3] . '/', '', $this->row[8]);
     }
 

--- a/app/Import/Specifics/IngDescription.php
+++ b/app/Import/Specifics/IngDescription.php
@@ -79,6 +79,7 @@ class IngDescription implements SpecificInterface
                 case 'DV':                               // Divers
                     $this->removeIBANIngDescription();   // Remove "IBAN:", because it is already at "Tegenrekening"
                     $this->removeNameIngDescription();   // Remove "Naam:", because it is already at "Naam/ Omschrijving"
+                    $this->removeIngDescription();       // Remove "Omschrijving", but not the value from description
                     // if "tegenrekening" empty, copy the description. Primitive, but it works.
                     $this->copyDescriptionToOpposite();
                     break;
@@ -98,6 +99,14 @@ class IngDescription implements SpecificInterface
     protected function addNameIngDescription(): void
     {
         $this->row[8] = $this->row[1] . ' ' . $this->row[8];
+    }
+
+    /**
+     * Remove "Omschrijving" (and NOT its value) from the description.
+     */
+    protected function removeIngDescription(): void
+    {
+        $this->row[8] = preg_replace('/Omschrijving: /', '', $this->row[8]);
     }
 
     /**

--- a/app/Import/Specifics/IngDescription.php
+++ b/app/Import/Specifics/IngDescription.php
@@ -76,8 +76,9 @@ class IngDescription implements SpecificInterface
                 case 'OV':                               // Overschrijving
                 case 'VZ':                               // Verzamelbetaling
                 case 'IC':                               // Incasso
-                    $this->removeIBANIngDescription();
-                    $this->removeNameIngDescription();
+                case 'DV':                               // Divers
+                    $this->removeIBANIngDescription();   // Remove "IBAN:", because it is already at "Tegenrekening"
+                    $this->removeNameIngDescription();   // Remove "Naam:", because it is already at "Naam/ Omschrijving"
                     // if "tegenrekening" empty, copy the description. Primitive, but it works.
                     $this->copyDescriptionToOpposite();
                     break;

--- a/app/Import/Specifics/IngDescription.php
+++ b/app/Import/Specifics/IngDescription.php
@@ -111,12 +111,11 @@ class IngDescription implements SpecificInterface
     }
 
     /**
-     * Remove name from the description (Remove everything before the description incl the word 'Omschrijving' ).
+     * Remove "Naam" (and its value) from the description.
      */
     protected function removeNameIngDescription(): void
     {
-        // Try remove everything before the 'Omschrijving'
-        $this->row[8] = preg_replace('/.+Omschrijving: /', '', $this->row[8]);
+        $this->row[8] = preg_replace('/Naam:.*?([a-zA-Z\/]+:)/', '$1', $this->row[8]);
     }
 
     /**


### PR DESCRIPTION
<!--
Before you create a new PR, please consider the following two considerations.

1) Pull request for the MASTER branch will be closed.
2) We cannot accept pull requests to add new currencies.

Thanks.
-->

Fixes issue #2642

Changes in this pull request:

- Added `DV` transaction type (Divers)
- Correctly remove `Naam` and it's value from `Mededelingen` collumn
- Remove the word `Omschrijving` from `Mededelingen` collumn
- Fix copy of bank account number and name when transaction is an transfer from/to saving account.
- Move `Valutadatum` from `Mededelingen` collumn to an own collumn. Right now the collumn itself has no name.

Todo:
- Add an name for the newly created collumn. I have done this hardcoded by adding this line:
``` php
array_push($headers, "Valutadatum"); // New row for "Valutadatum" (only for IngDescription.php specific import)
```
To here (between `$headers` and `// get example rows:` (line 253))
https://github.com/firefly-iii/firefly-iii/blob/af503597e62108cd7fedaa8ef89c80d161cbf304/app/Support/Import/JobConfiguration/File/ConfigureRolesHandler.php#L250-L255

@JC5 Do you have any idea how i can add an name for the newly created column in a more general way and only for the ING specific task?
