### PR TITLE
WIP: Fix #3335 Reconciliation account currency is wrong when base account has non-default currency

### DIFF
--- a/resources/lang/en_US/firefly.php
+++ b/resources/lang/en_US/firefly.php
@@ -205,7 +205,7 @@ return [
     'active_exp_bills_only'                      => 'active and expected bills only',
     'average_per_bill'                           => 'average per bill',
     'expected_total'                             => 'expected total',
-    'reconciliation_account_name'                => ':name reconciliation',
+    'reconciliation_account_name'                => ':name reconciliation (:currency)',
     // API access
     'authorization_request'                      => 'Firefly III v:version Authorization Request',
     'authorization_request_intro'                => '<strong>:client</strong> is requesting permission to access your financial administration. Would you like to authorize <strong>:client</strong> to access these records?',


### PR DESCRIPTION
<!--
Before you create a new PR, please consider the following two considerations.

1) Pull request for the MASTER branch will be closed.
2) We cannot accept pull requests to add new currencies.

Thanks.
-->

Fixes issue #3335 

Changes in this pull request:

- Add optional `$currencyId` argument to `AccountFactory::findOrCreate` method which passes currency_id to `AccountFactory::create` method
- Get currency_id of current account in `AccountRepository::getReconciliation` method if reconciliation is not created yet
- Pass `currencyId` to `AccountFactory::findOrCreate` method if available

@JC5
