### PR TITLE
Autofill budget from last period

### DIFF
--- a/public/v1/js/ff/budgets/index.js
+++ b/public/v1/js/ff/budgets/index.js
@@ -35,6 +35,8 @@ $(function () {
     $('.budget_amount').on('change', updateBudgetedAmount);
     $('.create_bl').on('click', createBudgetLimit);
 
+    $('.set_last_period').on('click', setBudgetLimitFromLastPeriod);
+
 
     /*
      When the input changes, update the percentages for the budgeted bar:
@@ -122,6 +124,18 @@ function updateBudgetedAmount(e) {
             alert('I failed :(');
         });
     }
+}
+
+function setBudgetLimitFromLastPeriod(e) {
+       
+    var button = $(e.currentTarget);
+    var budgetLimitId = button.data('id');
+    var targetAmount = button.data('value');
+
+    $('.budget_amount[data-limit="' + budgetLimitId + '"]').val(targetAmount);
+    $('.budget_amount[data-limit="' + budgetLimitId + '"]').change();
+    
+    return false;
 }
 
 function updateTotalBudgetedAmount(currencyId) {

--- a/resources/lang/en_US/firefly.php
+++ b/resources/lang/en_US/firefly.php
@@ -822,6 +822,7 @@ return [
     'auto_budget_help'                          => 'You can read more about this feature in the help. Click the top-right (?) icon.',
     'auto_budget_reset_icon'                    => 'This budget will be set periodically',
     'auto_budget_rollover_icon'                 => 'The budget amount will increase periodically',
+    'set_budget_from_last_period'               => 'Set budgeted amount from last period (:amount)',
 
     // bills:
     'match_between_amounts'                     => 'Bill matches transactions between :low and :high.',

--- a/resources/views/v1/budgets/index.twig
+++ b/resources/views/v1/budgets/index.twig
@@ -255,6 +255,18 @@
                                             <input class="form-control budget_amount" data-original="0" data-id="{{ budget.id }}"
                                                    data-currency="{{ defaultCurrency.id }}" data-limit="0" value="0" autocomplete="off" min="0" name="amount"
                                                    type="number">
+                                            {% if budget.last_limit > 0 %}
+                                                <div class="input-group-btn">
+                                                    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
+                                                            aria-expanded="false"><span class="caret"></span></button>
+                                                    <ul class="dropdown-menu">
+                                                        <li><a href="#" class="set_last_period" data-id="{{ budget.id }}"  data-value="{{ budget.last_limit }}">>
+                                                                <i class="fa fa-history" aria-hidden="true"></i>{{ trans('firefly.set_budget_from_last_period', {amount: formatAmountBySymbol(budget.last_limit, defaultCurrency.symbol, defaultCurrency.decimal_places, false )} )  }}
+                                                            </a>
+                                                        </li>
+                                                    </ul>
+                                                </div>
+                                            {% endif %}
                                         </div>
                                         <span class="text-danger budget_warning" data-id="{{ budget.id }}" data-budgetLimit="{{ budgetLimit.id }}"
                                               style="display:none;"></span>
@@ -271,9 +283,16 @@
                                                     <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
                                                             aria-expanded="false"><span class="caret"></span></button>
                                                     <ul class="dropdown-menu">
-                                                        <li><a href="{{ route('budget-limits.delete', [budgetLimit.id]) }}">Remove budgeted amount
+                                                        <li><a href="{{ route('budget-limits.delete', [budgetLimit.id]) }}"><i class="fa fa-trash" aria-hidden="true"></i>Remove budgeted amount
                                                                 in {{ budgetLimit.currency_name }}</a></li>
+                                                        {% if budgetLimit.last_period_amount > 0 %}
+                                                            <li><a href="#" class="set_last_period" data-id="{{ budgetLimit.id }}" data-value="{{ budgetLimit.last_period_amount }}">
+                                                                    <i class="fa fa-history" aria-hidden="true"></i>{{ trans('firefly.set_budget_from_last_period', {amount: formatAmountBySymbol(budgetLimit.last_period_amount, budgetLimit.currency_symbol, budgetLimit.currency_decimal_places, false )} )  }}
+                                                                </a>
+                                                            </li>
+                                                        {% endif %}
                                                     </ul>
+                                                    
                                                 </div>
                                             </div>
                                             {% if not budgetLimit.in_range %}


### PR DESCRIPTION
It's WIP but I wanted some feedback before fine-tuning it.

I've been working on this:
![image](https://user-images.githubusercontent.com/34862846/83753943-769e0380-a66b-11ea-8a77-39ba3c172da6.png)
If a budget was set for the previous period, a new item appears in the dropdown list and allows you to set that amount.
![image](https://user-images.githubusercontent.com/34862846/83754079-a947fc00-a66b-11ea-8699-143eb44ef2e7.png)

Back-end looks solid to me. Front-end still needs some fine-tuning to handle all cases.
I'm open to other front-end suggestions.

Possible improvement would be to be able to do it in bulk - haven't thought of the UI yet (let the user decide which budget lines to import?).