### PR TITLE
UTF8 locale support for Windows

### DIFF
--- a/app/Support/Steam.php
+++ b/app/Support/Steam.php
@@ -614,6 +614,11 @@ class Steam
         if ('equal' === $locale) {
             return $this->getLanguage();
         }
+        
+        // Check for Windows to replace the locale correctly.
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $locale = str_replace('_', '-', $locale);
+        }
 
         return $locale;
     }
@@ -627,7 +632,6 @@ class Steam
         return [
             sprintf('%s.utf8', $locale),
             sprintf('%s.UTF-8', $locale),
-            str_replace('_', '-', $locale), // for Windows.
         ];
     }
 

--- a/resources/lang/en_US/firefly.php
+++ b/resources/lang/en_US/firefly.php
@@ -573,7 +573,6 @@ return [
     'pref_locale'                               => 'Locale settings',
     'pref_languages_help'                       => 'Firefly III supports several languages. Which one do you prefer?',
     'pref_locale_help'                          => 'Firefly III allows you to set other local settings, like how currencies, numbers and dates are formatted. Entries in this list may not be supported by your system. Firefly III doesn\'t have the correct date settings for every locale; contact me for improvements.',
-    'pref_locale_no_windows'                    => 'This feature may not work on Windows.',
     'pref_locale_no_demo'                       => 'This feature won\'t work for the demo user.',
     'pref_custom_fiscal_year'                   => 'Fiscal year settings',
     'pref_custom_fiscal_year_label'             => 'Enabled',

--- a/resources/views/v1/preferences/index.twig
+++ b/resources/views/v1/preferences/index.twig
@@ -72,7 +72,6 @@
                                         <ul class="text-warning">
 
                                             {% if IS_DEMO_SITE %}<li class="text-danger">{{ 'pref_locale_no_demo'|_ }}</li>{% endif %}
-                                            <li>{{ 'pref_locale_no_windows'|_ }}</li>
                                             <li>{{ 'pref_locale_no_docker'|_ }}</li>
                                         </ul>
                                     </div>


### PR DESCRIPTION
Saw #3519 and noticed it still didn't fix my Windows 10 dev system: special characters were displayed as �
With this change it's all good. Tested with French, Russian and Polish.
This is the result of my personal research but the condition comes from PHP documentation: https://www.php.net/manual/en/function.strftime.php example number 3.

@JC5
