### PR TITLE
Remove mention of Docker when not running Docker

### DIFF
--- a/resources/lang/en_US/firefly.php
+++ b/resources/lang/en_US/firefly.php
@@ -574,7 +574,6 @@ return [
     'pref_languages_help'                       => 'Firefly III supports several languages. Which one do you prefer?',
     'pref_locale_help'                          => 'Firefly III allows you to set other local settings, like how currencies, numbers and dates are formatted. Entries in this list may not be supported by your system. Firefly III doesn\'t have the correct date settings for every locale; contact me for improvements.',
     'pref_locale_no_windows'                    => 'This feature may not work on Windows.',
-    'pref_locale_no_docker'                     => 'The Docker image only has a small set of installed locales.',
     'pref_locale_no_demo'                       => 'This feature won\'t work for the demo user.',
     'pref_custom_fiscal_year'                   => 'Fiscal year settings',
     'pref_custom_fiscal_year_label'             => 'Enabled',

--- a/resources/views/v1/preferences/index.twig
+++ b/resources/views/v1/preferences/index.twig
@@ -73,7 +73,6 @@
 
                                             {% if IS_DEMO_SITE %}<li class="text-danger">{{ 'pref_locale_no_demo'|_ }}</li>{% endif %}
                                             <li>{{ 'pref_locale_no_windows'|_ }}</li>
-                                            <li>{{ 'pref_locale_no_docker'|_ }}</li>
                                         </ul>
                                     </div>
                                     {% else %}


### PR DESCRIPTION
Following d774b4e, I suggest to remove Docker mention since this block is displayed only when not running Docker.

@JC5

Not sure what's your politic about unused strings, let me know if you want me to remove it (same for my other PR).