### PR TITLE
Fix "Let's create a piggy bank!" not being displayed anymore

### DIFF
--- a/app/Http/Controllers/PiggyBank/IndexController.php
+++ b/app/Http/Controllers/PiggyBank/IndexController.php
@@ -89,13 +89,7 @@ class IndexController extends Controller
         $parameters->set('end', $end);
 
         // make piggy bank groups:
-        $piggyBanks = [
-            0 => [ // the index is the order, not the ID.
-                   'object_group_id'    => 0,
-                   'object_group_title' => (string) trans('firefly.default_group_title_name'),
-                   'piggy_banks'        => [],
-            ],
-        ];
+        $piggyBanks = [];
 
         /** @var PiggyBankTransformer $transformer */
         $transformer = app(PiggyBankTransformer::class);
@@ -110,8 +104,8 @@ class IndexController extends Controller
             $groupOrder = (int) $array['object_group_order'];
             // make group array if necessary:
             $piggyBanks[$groupOrder] = $piggyBanks[$groupOrder] ?? [
-                    'object_group_id'    => $array['object_group_id'],
-                    'object_group_title' => $array['object_group_title'],
+                    'object_group_id'    => $array['object_group_id'] ?? 0,
+                    'object_group_title' => $array['object_group_title'] ?? trans('firefly.default_group_title_name'),
                     'piggy_banks'        => [],
                 ];
 


### PR DESCRIPTION
The recent implementation of groups to piggy banks does not handle correctly the case where no piggy banks are assigned to the default group.
When other piggy banks are assigned to a group, it is not visible. But when no piggy banks exist at all, the "Let's create a piggy bank!" frame is not displayed.
![image](https://user-images.githubusercontent.com/34862846/89125300-c9663100-d4dd-11ea-9a9a-c116895f522a.png)

@JC5
