### PR TITLE
Add config option to specify custom LDAP filter

### DIFF
--- a/app/Scopes/LdapFilterScope.php
+++ b/app/Scopes/LdapFilterScope.php
@@ -13,8 +13,8 @@ class LdapFilterScope implements ScopeInterface {
      */
     public function apply(Builder $query)
     {
-        $filter = config('ldap_auth.custom_filter');
-        if ( $filter ) {
+        $filter = (string) config('ldap_auth.custom_filter');
+        if ( '' !== $filter ) {
             $query->rawFilter($filter);
         }
     }

--- a/app/Scopes/LdapFilterScope.php
+++ b/app/Scopes/LdapFilterScope.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace FireflyIII\Scopes;
+
+use Adldap\Query\Builder;
+use Adldap\Laravel\Scopes\ScopeInterface;
+
+class LdapFilterScope implements ScopeInterface {
+    /**
+     * If the ADLDAP_AUTH_FILTER is provided, apply the filter to the LDAP query.
+     * @param Builder $query
+     * @return void
+     */
+    public function apply(Builder $query)
+    {
+        $filter = config('ldap_auth.custom_filter');
+        if ( $filter ) {
+            $query->rawFilter($filter);
+        }
+    }
+}

--- a/config/ldap_auth.php
+++ b/config/ldap_auth.php
@@ -22,6 +22,8 @@
 
 declare(strict_types=1);
 
+use FireflyIII\Scopes\LdapFilterScope;
+
 use Adldap\Laravel\Events\Authenticated;
 use Adldap\Laravel\Events\AuthenticatedModelTrashed;
 use Adldap\Laravel\Events\AuthenticatedWithWindows;
@@ -49,13 +51,17 @@ use Adldap\Laravel\Scopes\UpnScope;
 
 // default OpenLDAP scopes.
 $scopes = [
+    LdapFilterScope::class,
     UidScope::class,
 ];
 if ('FreeIPA' === env('ADLDAP_CONNECTION_SCHEME')) {
-    $scopes = [];
+    $scopes = [
+        LdapFilterScope::class,
+    ];
 }
 if ('ActiveDirectory' === env('ADLDAP_CONNECTION_SCHEME')) {
     $scopes = [
+        LdapFilterScope::class,
         UpnScope::class,
     ];
 }
@@ -373,5 +379,17 @@ return [
 
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom LDAP Filter
+    |--------------------------------------------------------------------------
+    |
+    | This value can be optionally provided to restrict LDAP queries to the
+    | given filter. It should be in LDAP filter format, and will be
+    | applied in the LdapFilterScope.
+    |
+    */
+    'custom_filter' => env('ADLDAP_AUTH_FILTER', ''),
 
 ];


### PR DESCRIPTION
<!--
Before you create a new PR, please consider:

1) Pull requests for the MAIN branch will be closed.
2) We cannot accept pull requests to add new currencies.
3) DO NOT include translations in your PR. Only English US sentences.

Thanks.
-->

Fixes issue #3723

Changes in this pull request:

- Add ldap_auth.custom filter option
- Add ADLDAP_AUTH_FILTER env reference
- Create LdapFilterScope to apply the filter (if one exists) to LDAP queries

@JC5
