### PR TITLE
Wrong query params in autocomplete

### DIFF
--- a/public/v1/js/ff/transactions/convert.js
+++ b/public/v1/js/ff/transactions/convert.js
@@ -39,7 +39,7 @@ function makeRevenueAC() {
         datumTokenizer: Bloodhound.tokenizers.obj.whitespace('name'),
         queryTokenizer: Bloodhound.tokenizers.whitespace,
         prefetch: {
-            url: 'api/v1/autocomplete/accounts?types=Revenue account?uid=' + uid,
+            url: 'api/v1/autocomplete/accounts?types=Revenue account&uid=' + uid,
             filter: function (list) {
                 return $.map(list, function (object) {
                     return {name: object.name};

--- a/public/v1/js/ff/transactions/mass/edit.js
+++ b/public/v1/js/ff/transactions/mass/edit.js
@@ -55,7 +55,7 @@ $(document).ready(function () {
                                            datumTokenizer: Bloodhound.tokenizers.obj.whitespace('name'),
                                            queryTokenizer: Bloodhound.tokenizers.whitespace,
                                            prefetch: {
-                                               url: 'api/v1/autocomplete/accounts?types=Expense account?uid=' + uid,
+                                               url: 'api/v1/autocomplete/accounts?types=Expense account&uid=' + uid,
                                                filter: function (list) {
                                                    return $.map(list, function (obj) {
                                                        return obj;
@@ -63,7 +63,7 @@ $(document).ready(function () {
                                                }
                                            },
                                            remote: {
-                                               url: 'api/v1/autocomplete/accounts?types=Expense account?query=%QUERY&uid=' + uid,
+                                               url: 'api/v1/autocomplete/accounts?types=Expense account&query=%QUERY&uid=' + uid,
                                                wildcard: '%QUERY',
                                                filter: function (list) {
                                                    return $.map(list, function (obj) {
@@ -83,7 +83,7 @@ $(document).ready(function () {
                                              datumTokenizer: Bloodhound.tokenizers.obj.whitespace('name'),
                                              queryTokenizer: Bloodhound.tokenizers.whitespace,
                                              prefetch: {
-                                                 url: 'api/v1/autocomplete/accounts?types=Revenue account?uid=' + uid,
+                                                 url: 'api/v1/autocomplete/accounts?types=Revenue account&uid=' + uid,
                                                  filter: function (list) {
                                                      return $.map(list, function (obj) {
                                                          return obj;
@@ -91,7 +91,7 @@ $(document).ready(function () {
                                                  }
                                              },
                                              remote: {
-                                                 url: 'api/v1/autocomplete/accounts?types=Revenue account?query=%QUERY&uid=' + uid,
+                                                 url: 'api/v1/autocomplete/accounts?types=Revenue account&query=%QUERY&uid=' + uid,
                                                  wildcard: '%QUERY',
                                                  filter: function (list) {
                                                      return $.map(list, function (obj) {


### PR DESCRIPTION
Query string with two ?, broke some autocompletes. Probably an unlucky search&replace while migrating to the new API.

Btw, wouldn't be cleaner to use "expense" and "revenue" instead of "Expense account" and "Revenue account", since it is supported by the API?