### PR TITLE
Fixes account notes parsing

### DIFF
--- a/resources/views/v1/accounts/show.twig
+++ b/resources/views/v1/accounts/show.twig
@@ -122,7 +122,7 @@
                         <h3 class="box-title">{{ 'notes'|_ }}</h3>
                     </div>
                     <div class="box-body">
-                        {{ account.notes.first.text|markdown }}
+                        {{ account.notes.first().text|markdown }}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Version: 5.4.1
Relates Issue: https://github.com/firefly-iii/firefly-iii/issues/3823

Error:
```
Argument 1 passed to FireflyIII\Support\Twig\General::FireflyIII\Support\Twig\{closure}() must be of the type string, null given, called in storage/framework/views/twig/6a/6ab16553233dcc8cfc89e313950594326064d2d4ed99b3d52dcd2fd762fd9075.php on line 245
```

**Changes in this pull request:**

- Fixes notes parsing on Account detail view (first should be called as method)

@JC5
