### PR TITLE
Add start_url to manifest file

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,6 +1,7 @@
 {
     "name": "Firefly III",
     "short_name": "Firefly III",
+    "start_url": "/",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",


### PR DESCRIPTION
Hi,

Re #3821 , It appears `start_url` is a mandatory field. See Chrome DevTools output:

![image](https://user-images.githubusercontent.com/7100147/94197617-50b89b00-feb6-11ea-8997-e9ed17d23505.png)

I'm serving Firefly over http, so you can ignore the first warning. The last warning is because Firefly is not offline-ready, i.e. does not use a service worker.

Thanks!
