### PR TITLE
Fix space ruble currency name

### DIFF
--- a/database/seeds/TransactionCurrencySeeder.php
+++ b/database/seeds/TransactionCurrencySeeder.php
@@ -61,7 +61,7 @@ class TransactionCurrencySeeder extends Seeder
         // asian currencies
         $currencies[] = ['code' => 'JPY', 'name' => 'Japanese yen', 'symbol' => '¥', 'decimal_places' => 2];
         $currencies[] = ['code' => 'RMB', 'name' => 'Chinese yuan', 'symbol' => '¥', 'decimal_places' => 2];
-        $currencies[] = ['code' => 'RUB', 'name' => 'Russian ruble ', 'symbol' => '₽', 'decimal_places' => 2];
+        $currencies[] = ['code' => 'RUB', 'name' => 'Russian ruble', 'symbol' => '₽', 'decimal_places' => 2];
         $currencies[] = ['code' => 'INR', 'name' => 'Indian rupee', 'symbol' => '₹', 'decimal_places' => 2];
 
         // international currencies


### PR DESCRIPTION
<!--
Before you create a new PR, please consider:

1) Pull requests for the MAIN branch will be closed.
2) We cannot accept pull requests to add new currencies.
3) DO NOT include translations in your PR. Only English US sentences.

Thanks.
-->

Hi. This fix for little mistake in ruble currency name as  ` `

Changes in this pull request:

- Change currency name from `Russian ruble ` to `Russian ruble`


@JC5
