### PR TITLE
Forward REMOTE_USER (remote_user_guard auth mode)

### DIFF
--- a/app/Support/Authentication/RemoteUserGuard.php
+++ b/app/Support/Authentication/RemoteUserGuard.php
@@ -67,9 +67,9 @@ class RemoteUserGuard implements Guard
 
             return;
         }
-        // Get the user identifier from $_SERVER
+        // Get the user identifier from $_SERVER or apache filtered headers
         $header = config('auth.guard_header', 'REMOTE_USER');
-        $userID = request()->server($header) ?? null;
+        $userID = request()->server($header) ?? apache_request_headers()[$header] ?? null;
         if (null === $userID) {
             Log::error(sprintf('No user in header "%s".', $header));
             throw new FireflyException('The guard header was unexpectedly empty. See the logs.');


### PR DESCRIPTION
Changes in this pull request:
493d399 - Fix a typo

be421d0 - Fix an issue I had using "remote_user_guard", the REMOTE_USER header was not forwarded to the app -> Exception "The guard header was unexpectedly empty. See the logs."

I know my fix is not perfect : if someone edit AUTHENTICATION_GUARD_HEADER to something different .. then it won't work anymore. Maybe a note should be added, or do you have another idea to forward that header ?





@JC5 
