### PR TITLE
Fix remote guard email header

### DIFF
--- a/app/Support/Authentication/RemoteUserGuard.php
+++ b/app/Support/Authentication/RemoteUserGuard.php
@@ -80,11 +80,14 @@ class RemoteUserGuard implements Guard
 
         // store email address if present in header and not already set.
         $header       = config('auth.guard_email');
-        $emailAddress = (string) (request()->server($header) ?? null);
-        $preference   = app('preferences')->getForUser($retrievedUser, 'remote_guard_alt_email', null);
 
-        if (null !== $emailAddress && null === $preference && $emailAddress !== $userID) {
-            app('preferences')->setForUser($retrievedUser, 'remote_guard_alt_email', $emailAddress);
+        if (null !== $header) {
+            $emailAddress = (string) (request()->server($header) ?? null);
+            $preference   = app('preferences')->getForUser($retrievedUser, 'remote_guard_alt_email', null);
+
+            if (null !== $emailAddress && null === $preference && $emailAddress !== $userID) {
+                app('preferences')->setForUser($retrievedUser, 'remote_guard_alt_email', $emailAddress);
+            }
         }
 
         Log::debug(sprintf('Result of getting user from provider: %s', $retrievedUser->email));


### PR DESCRIPTION
<!--
Before you create a new PR, please consider:

1) Pull requests for the MAIN branch will be closed.
2) We cannot accept pull requests to add new currencies.
3) DO NOT include translations in your PR. Only English US sentences.

Thanks.
-->

Fixes issue #4060

Changes in this pull request:

- Do not fail with 500 on missing `AUTHENTICATION_GUARD_EMAIL` configuration

@JC5
