### PR TITLE
Fix 'spent per day' budget box

### DIFF
--- a/app/Http/Controllers/Json/BoxController.php
+++ b/app/Http/Controllers/Json/BoxController.php
@@ -97,7 +97,8 @@ class BoxController extends Controller
         // also calculate spent per day.
         $spent       = $opsRepository->sumExpenses($start, $end, null, null, $currency);
         $spentAmount = $spent[(int) $currency->id]['sum'] ?? '0';
-        $days        = min( $today->diffInDays($start), $end->diffInDays($start) ) + 1;
+
+        $days = $today->between($start, $end) ? $today->diffInDays($start) + 1  : $end->diffInDays($start) + 1;
         $spentPerDay = bcdiv($spentAmount, (string) $days);
         if ($availableBudgets->count() > 0) {
             $display           = 0; // assume user overspent

--- a/app/Http/Controllers/Json/BoxController.php
+++ b/app/Http/Controllers/Json/BoxController.php
@@ -97,7 +97,7 @@ class BoxController extends Controller
         // also calculate spent per day.
         $spent       = $opsRepository->sumExpenses($start, $end, null, null, $currency);
         $spentAmount = $spent[(int) $currency->id]['sum'] ?? '0';
-        $days        = $today->diffInDays($start) + 1;
+        $days        = min( $today->diffInDays($start), $end->diffInDays($start) ) + 1;
         $spentPerDay = bcdiv($spentAmount, (string) $days);
         if ($availableBudgets->count() > 0) {
             $display           = 0; // assume user overspent

--- a/app/Http/Controllers/Json/BoxController.php
+++ b/app/Http/Controllers/Json/BoxController.php
@@ -97,7 +97,8 @@ class BoxController extends Controller
         // also calculate spent per day.
         $spent       = $opsRepository->sumExpenses($start, $end, null, null, $currency);
         $spentAmount = $spent[(int) $currency->id]['sum'] ?? '0';
-        $spentPerDay = '-1';
+        $days        = $today->diffInDays($start) + 1;
+        $spentPerDay = bcdiv($spentAmount, (string) $days);
         if ($availableBudgets->count() > 0) {
             $display           = 0; // assume user overspent
             $boxTitle          = (string) trans('firefly.overspent');


### PR DESCRIPTION
If no available budget is set, the budget box displays the total spent amount. The 'per day' amount is broken though, it's initialized to -1 but never set.
![image](https://user-images.githubusercontent.com/34862846/103458069-db563500-4d04-11eb-8fd5-459ea469ca94.png)

Tested with past and future periods as well.

@JC5

On a side note, I wonder if the negative amount is intended? If it's spent it's obviously negative. Same goes for 'Bills to pay' box.