### PR TITLE
Set Japanese Yen decimal places to zero in the TransactionCurrencySeeder

### DIFF
--- a/database/seeders/TransactionCurrencySeeder.php
+++ b/database/seeders/TransactionCurrencySeeder.php
@@ -62,7 +62,7 @@ class TransactionCurrencySeeder extends Seeder
         $currencies[] = ['code' => 'ZAR', 'name' => 'South African rand', 'symbol' => 'R', 'decimal_places' => 2];
 
         // asian currencies
-        $currencies[] = ['code' => 'JPY', 'name' => 'Japanese yen', 'symbol' => '¥', 'decimal_places' => 2];
+        $currencies[] = ['code' => 'JPY', 'name' => 'Japanese yen', 'symbol' => '¥', 'decimal_places' => 0];
         $currencies[] = ['code' => 'RMB', 'name' => 'Chinese yuan', 'symbol' => '¥', 'decimal_places' => 2];
         $currencies[] = ['code' => 'RUB', 'name' => 'Russian ruble', 'symbol' => '₽', 'decimal_places' => 2];
         $currencies[] = ['code' => 'INR', 'name' => 'Indian rupee', 'symbol' => '₹', 'decimal_places' => 2];


### PR DESCRIPTION
<!--
Before you create a new PR, please consider:

1) Pull requests for the MAIN branch will be closed.
2) We cannot accept pull requests to add new currencies.
3) DO NOT include translations in your PR. Only English US sentences.

Thanks.
-->


Changes in this pull request:

- Set Japanese Yen decimal places to zero.

@JC5
