### PR TITLE
Fixed amountPerPeriod not respecting bill skips

### DIFF
--- a/app/Http/Controllers/Bill/IndexController.php
+++ b/app/Http/Controllers/Bill/IndexController.php
@@ -211,8 +211,8 @@ class IndexController extends Controller
             'monthly'   => '12',
             'weekly'    => '52.17',
         ];
-        $yearAmount = bcmul($avg, $multiplies[$bill['repeat_freq']]);
-        Log::debug(sprintf('Amount per year is %s (%s * %s)', $yearAmount, $avg, $multiplies[$bill['repeat_freq']]));
+        $yearAmount = bcmul($avg, bcdiv($multiplies[$bill['repeat_freq']], ''.($bill['skip'] + 1)));       
+        Log::debug(sprintf('Amount per year is %s (%s * %s / %s)', $yearAmount, $avg, $multiplies[$bill['repeat_freq']], ''.($bill['skip'] + 1)));
 
         // per period:
         $division  = [

--- a/app/Http/Controllers/Bill/IndexController.php
+++ b/app/Http/Controllers/Bill/IndexController.php
@@ -211,8 +211,8 @@ class IndexController extends Controller
             'monthly'   => '12',
             'weekly'    => '52.17',
         ];
-        $yearAmount = bcmul($avg, bcdiv($multiplies[$bill['repeat_freq']], ''.($bill['skip'] + 1)));       
-        Log::debug(sprintf('Amount per year is %s (%s * %s / %s)', $yearAmount, $avg, $multiplies[$bill['repeat_freq']], ''.($bill['skip'] + 1)));
+        $yearAmount = bcmul($avg, bcdiv($multiplies[$bill['repeat_freq']], (string)($bill['skip'] + 1)));       
+        Log::debug(sprintf('Amount per year is %s (%s * %s / %s)', $yearAmount, $avg, $multiplies[$bill['repeat_freq']], (string)($bill['skip'] + 1)));
 
         // per period:
         $division  = [


### PR DESCRIPTION
Changes in this pull request:
- Interface bills overview did not show expected monthy costs correctly (skips were ignored)
- amountPerPeriod() has been adapted to include skips

@JC5
