### PR TITLE
BUGFIX: sqlite does not return int types

### DIFF
--- a/app/Jobs/CreateAutoBudgetLimits.php
+++ b/app/Jobs/CreateAutoBudgetLimits.php
@@ -129,7 +129,7 @@ class CreateAutoBudgetLimits implements ShouldQueue
 
         // find budget limit:
         $budgetLimit = $this->findBudgetLimit($autoBudget->budget, $start, $end);
-        $type = $autoBudget->auto_budget_type;
+
         if (null === $budgetLimit && AutoBudget::AUTO_BUDGET_RESET === (int)$autoBudget->auto_budget_type) {
             // that's easy: create one.
             // do nothing else.

--- a/app/Jobs/CreateAutoBudgetLimits.php
+++ b/app/Jobs/CreateAutoBudgetLimits.php
@@ -129,8 +129,8 @@ class CreateAutoBudgetLimits implements ShouldQueue
 
         // find budget limit:
         $budgetLimit = $this->findBudgetLimit($autoBudget->budget, $start, $end);
-
-        if (null === $budgetLimit && AutoBudget::AUTO_BUDGET_RESET === $autoBudget->auto_budget_type) {
+        $type = $autoBudget->auto_budget_type;
+        if (null === $budgetLimit && AutoBudget::AUTO_BUDGET_RESET === (int)$autoBudget->auto_budget_type) {
             // that's easy: create one.
             // do nothing else.
             $this->createBudgetLimit($autoBudget, $start, $end);
@@ -139,7 +139,7 @@ class CreateAutoBudgetLimits implements ShouldQueue
             return;
         }
 
-        if (null === $budgetLimit && AutoBudget::AUTO_BUDGET_ROLLOVER === $autoBudget->auto_budget_type) {
+        if (null === $budgetLimit && AutoBudget::AUTO_BUDGET_ROLLOVER === (int)$autoBudget->auto_budget_type) {
             // budget limit exists already,
             $this->createRollover($autoBudget);
             Log::debug(sprintf('Done with auto budget #%d', $autoBudget->id));


### PR DESCRIPTION
Fixes issue (none)

Changes in this pull request:
When trying to fin the reason why new budget limits were not created by the cronjob it appeared that sqlite does not return php integers for integer types. Instead it returns a string for everything.
This PR resolves this by casting the auto_budget_type to int

@JC5
