### PR TITLE
Update menu-sidebar.twig

### DIFF
--- a/resources/views/v1/partials/menu-sidebar.twig
+++ b/resources/views/v1/partials/menu-sidebar.twig
@@ -126,7 +126,7 @@
         </ul>
     </li>
 
-    <li class="{{ activeRoutePartial('categories') }} {{ activeRoutePartial('tags') }} treeview">
+    <li class="{{ activeRoutePartial('categories') }} {{ activeRoutePartial('tags') }} {{ activeRoutePartial('groups') }} treeview">
         <a href="#">
             <i class="fa fa-tags fa-fw"></i>
             <span>{{ 'classification'|_ }}</span>


### PR DESCRIPTION
Small changes for the Classification in the menu-sidebar.
When route `groups` is active add class `menu-open` by adding this code `{{ activeRoutePartial('groups') }}`

Changes in this pull request:

- Make "Classification" menu is open when child "groups" is open
