### PR TITLE
healthcheck endpoint

### DIFF
--- a/app/Http/Controllers/HealthcheckController.php
+++ b/app/Http/Controllers/HealthcheckController.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * HealthcheckController.php
+ * Copyright (c) 2019 james@firefly-iii.org
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+declare(strict_types=1);
+
+namespace FireflyIII\Http\Controllers;
+
+use Illuminate\Http\Response;
+
+/**
+ * Class HealthcheckController.
+ */
+class HealthcheckController extends Controller
+{
+    /**
+     * Sends 'OK' info when app is alive
+     *
+     * @return Response
+     */
+    public function check(): Response
+    {
+        return response('OK', 200);
+    }
+
+}
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,6 +68,9 @@ Route::group(
         // Change email routes:
         Route::get('profile/confirm-email-change/{token}', ['uses' => 'ProfileController@confirmEmailChange', 'as' => 'profile.confirm-email-change']);
         Route::get('profile/undo-email-change/{token}/{oldAddressHash}', ['uses' => 'ProfileController@undoEmailChange', 'as' => 'profile.undo-email-change']);
+
+        // Healthcheck route:
+        Route::get('health', ['uses' => 'HealthcheckController@check', 'as' => 'healthcheck']);
     }
 );
 


### PR DESCRIPTION
Changes in this pull request:

- This PR adds a /health endpoint which does nothing more than returning plaintext OK response. It is useful for service discovery tools (consul/kubernetes etc.), to quickly say, that service is alive and running. 

@JC5
