### PR TITLE
Bugfix: Safari redirecting to serviceworker.js

### DIFF
--- a/app/Support/Http/Controllers/UserNavigation.php
+++ b/app/Support/Http/Controllers/UserNavigation.php
@@ -172,7 +172,7 @@ trait UserNavigation
      */
     final protected function rememberPreviousUri(string $identifier): ?string
     {
-        $return = app('url')->previous();
+        $return = session()->previousUrl();
         /** @var ViewErrorBag|null $errors */
         $errors    = session()->get('errors');
         $forbidden = ['json', 'debug'];


### PR DESCRIPTION
Fixes issue #5110

Changes in this pull request:

The fix in storeCurrentUrl was good, but the URL used for the redirect was taken from `app('url')->previous()` which seems to have another source? (haven't used laravel for a very long time) However `session()->previousUrl()` contains the correct saved url from storeCurrentUrl and fixes the issue with redirect to serviceworker.js in safari on iOS and macOS.

@JC5
