### PR TITLE
Bugfix: Foreign Amount rounded on some pages

### DIFF
--- a/app/Transformers/TransactionGroupTransformer.php
+++ b/app/Transformers/TransactionGroupTransformer.php
@@ -351,7 +351,7 @@ class TransactionGroupTransformer extends AbstractTransformer
         $bill            = $this->getBill($journal->bill);
 
         if (null !== $foreignAmount && null !== $foreignCurrency) {
-            $foreignAmount = number_format((float)$foreignAmount, $foreignCurrency->decimal_places ?? 0, '.', '');
+            $foreignAmount = number_format((float)$foreignAmount, $foreignCurrency['decimal_places'] ?? 0, '.', '');
         }
 
         $longitude = null;


### PR DESCRIPTION
Changes in this pull request:

The PR fixes a bug that rounds foreign amounts on some pages  (/transactions/show/XXX for instance)
This minor bug has been introduced in 5.6.0

@JC5
