### PR TITLE
Drop default case. OpenLDAP is already the default (see #5279)

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -35,9 +35,6 @@ switch(env('LDAP_DIALECT')) {
     case 'FreeIPA':
         $ldapModel = class_exists(LdapRecord\Models\FreeIPA\User::class) ? LdapRecord\Models\FreeIPA\User::class : '';
         break;
-    default:
-        # default to openLDAP
-        $ldapModel = class_exists(LdapRecord\Models\OpenLDAP\User::class) ? LdapRecord\Models\OpenLDAP\User::class : ''; 
 }
 
 return [


### PR DESCRIPTION
For reference:
#5279
#5231 

