### PR TITLE
Bugfix: Empty pre-filled value in auto-budgets

### DIFF
--- a/app/Http/Controllers/Budget/EditController.php
+++ b/app/Http/Controllers/Budget/EditController.php
@@ -103,7 +103,7 @@ class EditController extends Controller
         ];
         if ($autoBudget) {
             $amount                          = $hasOldInput ? $request->old('auto_budget_amount') : $autoBudget->amount;
-            $preFilled['auto_budget_amount'] = number_format((float)$amount, $autoBudget->transactionCurrency->decimal_places);
+            $preFilled['auto_budget_amount'] = number_format((float)$amount, $autoBudget->transactionCurrency->decimal_places, '.', '');
         }
 
         // put previous url in session if not redirect from store (not "return_to_edit").


### PR DESCRIPTION
The auto-budget pre-filled value is empty when the set amount is above 1000 (view /budgets/edit/X).

The root cause was the function 'number_format' returning a string that
cannot be casted to a float when the amount is above 1000, because of the
thousands separator.

Introduced by commit b2eeeed0af in 5.6.5.

@JC5
