### PR TITLE
assign collection

### DIFF
--- a/app/Generator/Report/Budget/MonthReportGenerator.php
+++ b/app/Generator/Report/Budget/MonthReportGenerator.php
@@ -51,7 +51,7 @@ class MonthReportGenerator implements ReportGeneratorInterface
      */
     public function __construct()
     {
-        $this->expenses = [];
+        $this->expenses = collect();
     }
 
     /**


### PR DESCRIPTION
When generating a Financereport for Budgets an error occures:

```
Cannot assign array to property FireflyIII\Generator\Report\Budget\MonthReportGenerator::$expenses of type 
 lluminate\Support\Collection 
```

Hope this helps and thanks for your great work✌️

**Changes in this pull request:**

- assign collection instead of array to `$expenses` property in `Generator\Report\Budget\MonthReportGenerator`


@JC5
