### PR TITLE
direct link to contributing docs in readme.md

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,3 +1,0 @@
-# [Contributing guidelines](https://docs.firefly-iii.org/other-pages/contributing)
-
-[Contributing guidelines](https://docs.firefly-iii.org/other-pages/contributing)

--- a/readme.md
+++ b/readme.md
@@ -140,7 +140,7 @@ There are many ways to run Firefly III
 
 You can contact me at [james@firefly-iii.org](mailto:james@firefly-iii.org), you may open an issue in the [main repository](https://github.com/firefly-iii/firefly-iii) or contact me through [gitter](https://gitter.im/firefly-iii/firefly-iii) and [Twitter](https://twitter.com/Firefly_III).
 
-Of course, there are some [contributing guidelines](https://github.com/firefly-iii/firefly-iii/blob/main/.github/contributing.md) and a [code of conduct](https://github.com/firefly-iii/firefly-iii/blob/main/.github/code_of_conduct.md), which I invite you to check out.
+Of course, there are some [contributing guidelines](https://docs.firefly-iii.org/firefly-iii/other-pages/contributing) and a [code of conduct](https://github.com/firefly-iii/firefly-iii/blob/main/.github/code_of_conduct.md), which I invite you to check out.
 
 I can always use your help [squashing bugs](https://docs.firefly-iii.org/support/contribute#bugs), thinking about [new features](https://docs.firefly-iii.org/support/contribute#feature-requests) or [translating Firefly III](https://docs.firefly-iii.org/support/contribute#translations) into other languages.
 


### PR DESCRIPTION
<!--
Before you create a new PR, please consider:

1) Pull requests for the MAIN branch will be closed.
2) DO NOT include translations in your PR. Only English US sentences.

Thanks.
-->

Changes in this pull request:

- I have updated the readme.md to directly point the contributing documentation on the project website instead a GitHub landing
- Removed .github/contributing.md which is unnecessary at this point

@JC5
