### PR TITLE
feat: add the ability to disable mime check on attachement upload

### DIFF
--- a/config/firefly.php
+++ b/config/firefly.php
@@ -283,6 +283,12 @@ return [
         'application/vnd.oasis.opendocument.formula',
         'application/vnd.oasis.opendocument.database',
         'application/vnd.oasis.opendocument.image',
+
+        /* EML */
+        'message/rfc822',
+
+        /* JSON */
+        'application/json',
     ],
     'accountRoles'                 => ['defaultAsset', 'sharedAsset', 'savingAsset', 'ccAsset', 'cashWalletAsset'],
     'valid_liabilities'            => [AccountType::DEBT, AccountType::LOAN, AccountType::MORTGAGE],


### PR DESCRIPTION
This add the ability to disable mime check on file upload.
(In my case I want to upload eml mail file and json metadata)

Changes in this pull request:

- Add a new env variable `DISABLE_UPLOAD_MIME_CHECK` to control the new behavior
- Edited `AttachmentHelper.php` to create that new behavior

@JC5
