### PR TITLE
Use Piggy Bank's start date in suggested monthly calc

### DIFF
--- a/app/Repositories/PiggyBank/PiggyBankRepository.php
+++ b/app/Repositories/PiggyBank/PiggyBankRepository.php
@@ -341,7 +341,8 @@ class PiggyBankRepository implements PiggyBankRepositoryInterface
         }
         if (null !== $piggyBank->targetdate && $repetition->currentamount < $piggyBank->targetamount) {
             $now             = Carbon::now();
-            $diffInMonths    = $now->diffInMonths($piggyBank->targetdate, false);
+            $startDate       = null !== $piggyBank->startdate && $piggyBank->startdate->gte($now) ? $piggyBank->startdate : $now;
+            $diffInMonths    = $startDate->diffInMonths($piggyBank->targetdate, false);
             $remainingAmount = bcsub($piggyBank->targetamount, $repetition->currentamount);
 
             // more than 1 month to go and still need money to save:


### PR DESCRIPTION
Fixes issue #6254

Changes in this pull request:

- Factor in PiggyBank->startdate into getSuggestedMonthlyAmount to enable time bound calculations

@JC5
