### PR TITLE
Redis username needed for both databases

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -150,6 +150,7 @@ return [
             'path'     => envNonEmpty('REDIS_PATH'),
             'host'     => envNonEmpty('REDIS_HOST', '127.0.0.1'),
             'port'     => envNonEmpty('REDIS_PORT', 6379),
+            'username' => env('REDIS_USERNAME'),
             'password' => env('REDIS_PASSWORD', null),
             'database' => env('REDIS_DB', '0'),
         ],


### PR DESCRIPTION
Redis username needed for both 'default' and 'cache' databases.

I got this error message after updating firefly III to 5.7.11 :

```
 php ./artisan cache:clear

   Predis\Connection\ConnectionException 

  `AUTH` failed: WRONGPASS invalid username-password pair or user is disabled. [unix:/var/lib/redis/redis.sock]

  at vendor/predis/predis/src/Connection/AbstractConnection.php:132
    128▕      */
    129▕     protected function onConnectionError($message, $code = 0)
    130▕     {
    131▕         CommunicationException::handle(
  ➜ 132▕             new ConnectionException($this, "$message [{$this->getParameters()}]", $code)
    133▕         );
    134▕     }
    135▕ 
    136▕     /**

      +25 vendor frames 
  26  artisan:37
      Illuminate\Foundation\Console\Kernel::handle()
```
