### PR TITLE
Make bulk rules clauses match bulk TransactionController params

### DIFF
--- a/config/bulk.php
+++ b/config/bulk.php
@@ -27,10 +27,10 @@ use FireflyIII\Enums\ClauseType;
 return [
     ClauseType::TRANSACTION => [
         ClauseType::WHERE  => [
-            'source_account_id' => 'required|numeric|belongsToUser:accounts,id',
+            'account_id' => 'required|numeric|belongsToUser:accounts,id',
         ],
         ClauseType::UPDATE => [
-            'destination_account_id' => 'required|numeric|belongsToUser:accounts,id',
+            'account_id' => 'required|numeric|belongsToUser:accounts,id',
         ],
     ],
 ];


### PR DESCRIPTION
<!--
Before you create a new PR, please consider:

1) Pull requests for the MAIN branch will be closed.
2) DO NOT include translations in your PR. Only English US sentences.

Thanks.
-->

Changes in this pull request:

- Ensures that the validation rules for bulk endpoint match what the bulk TransactionController expects: `source_account_id` and `destination_account_id` ==> `account_id`

---

Hey @JC5, I just started using Firefly III, and noticed that the `/api/v1/data/bulk/transactions` endpoint did not work as expected. With my limited PHP foo I was able to pin-point it to a mismatch on argument names, as I was getting the error

> JSON contains an invalid key for the \"where\"-clause

despite using the right keys. Changing the validation rules accordingly fixes the problem. I validated this PR in my local instance, where I can now change transactions in bulk as expected. 👌 

Thanks for creating Firefly III in the first place, I really enjoy getting to know it!

Cheers!


