### PR TITLE
Ensure `remote_guard_alt_email` if changed

### DIFF
--- a/app/Support/Authentication/RemoteUserGuard.php
+++ b/app/Support/Authentication/RemoteUserGuard.php
@@ -84,7 +84,7 @@ class RemoteUserGuard implements Guard
             $emailAddress = (string) (request()->server($header) ?? null);
             $preference   = app('preferences')->getForUser($retrievedUser, 'remote_guard_alt_email');
 
-            if (null !== $emailAddress && null === $preference && $emailAddress !== $userID) {
+            if (null !== $emailAddress && (null === $preference || $preference["data"] !== $emailAddress) && $emailAddress !== $userID) {
                 app('preferences')->setForUser($retrievedUser, 'remote_guard_alt_email', $emailAddress);
             }
         }


### PR DESCRIPTION
If the header value for email in proxy auth changes, also update in the database.
