### PR TITLE
Implement new actions to remove strings from transaction's descriptions

### DIFF
--- a/app/TransactionRules/Actions/RemoveFirstFromDescription.php
+++ b/app/TransactionRules/Actions/RemoveFirstFromDescription.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * RemoveFirstFromDescription.php
+ * Copyright (c) 2023 sascha@knott.ac
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+declare(strict_types=1);
+
+namespace FireflyIII\TransactionRules\Actions;
+
+use DB;
+use FireflyIII\Models\RuleAction;
+
+/**
+ * Class ReplaceFirstDescription.
+ */
+class RemoveFirstFromDescription.php implements ActionInterface
+{
+    /** @var RuleAction The rule action */
+    private $action;
+
+    /**
+     * TriggerInterface constructor.
+     *
+     * @param RuleAction $action
+     */
+    public function __construct(RuleAction $action)
+    {
+        $this->action = $action;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function actOnArray(array $journal): bool
+    {
+        $action_value = $this->action->action_value
+        $before = $journal['description']
+
+        // remove first occurrence
+        $pos = strpos($before, $action_value);
+        if ($pos !== false) {
+            $after = substr_replace($before, '', $pos, strlen($action_value));
+        }
+
+        DB::table('transaction_journals')->where('id', $journal['transaction_journal_id'])->limit(1)->update(['description' => $after]);
+
+        return true;
+    }
+}

--- a/app/TransactionRules/Actions/RemoveFirstFromDescription.php
+++ b/app/TransactionRules/Actions/RemoveFirstFromDescription.php
@@ -48,8 +48,8 @@ class RemoveFirstFromDescription.php implements ActionInterface
      */
     public function actOnArray(array $journal): bool
     {
-        $action_value = $this->action->action_value
-        $before = $journal['description']
+        $action_value = $this->action->action_value;
+        $before = $journal['description'];
 
         // remove first occurrence
         $pos = strpos($before, $action_value);

--- a/app/TransactionRules/Actions/RemoveFirstFromDescription.php
+++ b/app/TransactionRules/Actions/RemoveFirstFromDescription.php
@@ -59,6 +59,13 @@ class RemoveFirstFromDescription.php implements ActionInterface
 
         DB::table('transaction_journals')->where('id', $journal['transaction_journal_id'])->limit(1)->update(['description' => $after]);
 
+        // journal
+        /** @var TransactionJournal $object */
+        $object = TransactionJournal::where('user_id', $journal['user_id'])->find($journal['transaction_journal_id']);
+
+        // audit log
+        event(new TriggeredAuditLog($this->action->rule, $object, 'update_description', $before, $after));
+
         return true;
     }
 }

--- a/app/TransactionRules/Actions/RemoveFirstFromDescription.php
+++ b/app/TransactionRules/Actions/RemoveFirstFromDescription.php
@@ -26,7 +26,7 @@ use DB;
 use FireflyIII\Models\RuleAction;
 
 /**
- * Class ReplaceFirstDescription.
+ * Class RemoveFirstFromDescription.
  */
 class RemoveFirstFromDescription.php implements ActionInterface
 {

--- a/app/TransactionRules/Actions/RemoveFromDescription.php
+++ b/app/TransactionRules/Actions/RemoveFromDescription.php
@@ -56,6 +56,13 @@ class RemoveFromDescription implements ActionInterface
 
         DB::table('transaction_journals')->where('id', $journal['transaction_journal_id'])->limit(1)->update(['description' => $after]);
 
+        // journal
+        /** @var TransactionJournal $object */
+        $object = TransactionJournal::where('user_id', $journal['user_id'])->find($journal['transaction_journal_id']);
+
+        // audit log
+        event(new TriggeredAuditLog($this->action->rule, $object, 'update_description', $before, $after));
+
         return true;
     }
 }

--- a/app/TransactionRules/Actions/RemoveFromDescription.php
+++ b/app/TransactionRules/Actions/RemoveFromDescription.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * RemoveFromDescription.php
+ * Copyright (c) 2023 sascha@knott.ac
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+declare(strict_types=1);
+
+namespace FireflyIII\TransactionRules\Actions;
+
+use DB;
+use FireflyIII\Models\RuleAction;
+
+/**
+ * Class RemoveFromDescription.
+ */
+class RemoveFromDescription implements ActionInterface
+{
+    /** @var RuleAction The rule action */
+    private $action;
+
+    /**
+     * TriggerInterface constructor.
+     *
+     * @param RuleAction $action
+     */
+    public function __construct(RuleAction $action)
+    {
+        $this->action = $action;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function actOnArray(array $journal): bool
+    {
+        $action_value = $this->action->action_value;
+        $before = $journal['description'];
+
+        // replace all occurrences
+        $after = str_replace($action_value, '', $before);
+
+        DB::table('transaction_journals')->where('id', $journal['transaction_journal_id'])->limit(1)->update(['description' => $after]);
+
+        return true;
+    }
+}

--- a/app/TransactionRules/Actions/RemoveViaRegex.php
+++ b/app/TransactionRules/Actions/RemoveViaRegex.php
@@ -48,8 +48,8 @@ class RemoveViaRegex implements ActionInterface
      */
     public function actOnArray(array $journal): bool
     {
-        $action_value = $this->action->action_value
-        $before = $journal['description']
+        $action_value = $this->action->action_value;
+        $before = $journal['description'];
 
         // remove via regex occurrence
         $replace = '';

--- a/app/TransactionRules/Actions/RemoveViaRegex.php
+++ b/app/TransactionRules/Actions/RemoveViaRegex.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * RemoveViaRegex.php
+ * Copyright (c) 2023 sascha@knott.ac
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+declare(strict_types=1);
+
+namespace FireflyIII\TransactionRules\Actions;
+
+use DB;
+use FireflyIII\Models\RuleAction;
+
+/**
+ * Class RemoveViaRegex.
+ */
+class RemoveViaRegex implements ActionInterface
+{
+    /** @var RuleAction The rule action */
+    private $action;
+
+    /**
+     * TriggerInterface constructor.
+     *
+     * @param RuleAction $action
+     */
+    public function __construct(RuleAction $action)
+    {
+        $this->action = $action;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function actOnArray(array $journal): bool
+    {
+        $action_value = $this->action->action_value
+        $before = $journal['description']
+
+        // remove via regex occurrence
+        $replace = '';
+        $after = preg_replace($action_value, $replace, $before);
+
+        DB::table('transaction_journals')->where('id', $journal['transaction_journal_id'])->limit(1)->update(['description' => $after]);
+
+        return true;
+    }
+}

--- a/app/TransactionRules/Actions/RemoveViaRegex.php
+++ b/app/TransactionRules/Actions/RemoveViaRegex.php
@@ -57,6 +57,13 @@ class RemoveViaRegex implements ActionInterface
 
         DB::table('transaction_journals')->where('id', $journal['transaction_journal_id'])->limit(1)->update(['description' => $after]);
 
+        // journal
+        /** @var TransactionJournal $object */
+        $object = TransactionJournal::where('user_id', $journal['user_id'])->find($journal['transaction_journal_id']);
+
+        // audit log
+        event(new TriggeredAuditLog($this->action->rule, $object, 'update_description', $before, $after));
+
         return true;
     }
 }

--- a/config/firefly.php
+++ b/config/firefly.php
@@ -76,8 +76,11 @@ use FireflyIII\TransactionRules\Actions\MoveDescriptionToNotes;
 use FireflyIII\TransactionRules\Actions\MoveNotesToDescription;
 use FireflyIII\TransactionRules\Actions\PrependDescription;
 use FireflyIII\TransactionRules\Actions\PrependNotes;
+use FireflyIII\TransactionRules\Actions\RemoveFirstFromDescription;
+use FireflyIII\TransactionRules\Actions\RemoveFromDescription;
 use FireflyIII\TransactionRules\Actions\RemoveAllTags;
 use FireflyIII\TransactionRules\Actions\RemoveTag;
+use FireflyIII\TransactionRules\Actions\RemoveViaRegex;
 use FireflyIII\TransactionRules\Actions\SetBudget;
 use FireflyIII\TransactionRules\Actions\SetCategory;
 use FireflyIII\TransactionRules\Actions\SetDescription;
@@ -484,6 +487,9 @@ return [
         'set_description'         => SetDescription::class,
         'append_description'      => AppendDescription::class,
         'prepend_description'     => PrependDescription::class,
+        'remove_description'      => RemoveFirstFromDescription::class,
+        'removefirst_description' => RemoveFromDescription::class,
+        'removeregex_description' => RemoveViaRegex::class,        
         'set_source_account'      => SetSourceAccount::class,
         'set_destination_account' => SetDestinationAccount::class,
         'set_notes'               => SetNotes::class,
@@ -509,6 +515,9 @@ return [
         'set_description',
         'append_description',
         'prepend_description',
+        'remove_description',
+        'removefirst_description',
+        'removeregex_description',
         'set_source_account',
         'set_destination_account',
         'set_notes',


### PR DESCRIPTION
Changes in this pull request:

I have added three actions that can be used in automation -> rules to modify a transaction's description:
- Remove the first occurrence of a string
- Remove all occurrences of a string
- Remove using a RegEx-pattern

I've tested these actions locally and they seems to work robustly.

The trigger for these was https://github.com/firefly-iii/firefly-iii/issues/5403, where ING Germany in combination with Nordigen contains `mandatereference:,creditorid:,remittanceinformation:` in front of the description.

I'm not a professional programmer, so please let me know if there is something that needs to be added to the PR.