### PR TITLE
Hide sensitive information in 2FA setup page when printing

### DIFF
--- a/resources/views/profile/code.twig
+++ b/resources/views/profile/code.twig
@@ -14,17 +14,14 @@
                         <h3 class="box-title">{{ 'pref_two_factor_auth_code'|_ }}</h3>
                     </div>
                     <div class="box-body">
-                        <p class="text-info">
+                        <p class="text-info hidden-print">
                             {{ 'pref_two_factor_auth_code_help'|_ }}
                         </p>
                         <div class="form group">
-                            <div class="col-sm-8 col-md-offset-4">
-                                <!--<img src="" alt="" title=""
-                                     style="border:1px #ddd solid;"/>
-                                     -->
+                            <div class="col-sm-8 col-md-offset-4 hidden-print">
                                 {{ image|raw }}
                             </div>
-                            <p>
+                            <p class="hidden-print">
                                 {{ trans('firefly.2fa_use_secret_instead', {secret: secret|escape})|raw }}
                             </p>
                             <p>


### PR DESCRIPTION
The QR code (and manual code) should not be recoverable after the initial setup. This would allow an unauthorized person to access an account without leaving a trace (like showing that a backup code was used, given that person has the account password).

Even if very low, having that information visible could be a problem.

<!--
Before you create a new PR, please consider:

1) Pull requests for the MAIN branch will be closed.
2) DO NOT include translations in your PR. Only English US sentences.

Thanks.
-->
---
Changes in this pull request:

- Add CSS classes to hide sensitive information when printing the 2FA setup page
- Hide instructions on how to use the QR code
- Remove dead code

Previews:

![2023-01-09_21-52](https://user-images.githubusercontent.com/1571895/211451121-7030265c-051a-4381-85c3-556e76739e27.png)

![2023-01-09_21-53](https://user-images.githubusercontent.com/1571895/211451138-d3512f92-d957-42b3-b3f9-00ac239be86d.png)

@JC5
