### PR TITLE
Do not validate currency if account has no currency configured

### DIFF
--- a/app/Validation/Api/Data/Bulk/ValidatesBulkTransactionQuery.php
+++ b/app/Validation/Api/Data/Bulk/ValidatesBulkTransactionQuery.php
@@ -67,8 +67,16 @@ trait ValidatesBulkTransactionQuery
 
                 return;
             }
+
             // must have same currency:
-            if ($repository->getAccountCurrency($source)->id !== $repository->getAccountCurrency($dest)->id) {
+            // some account types (like expenses) do not have currency, so they have to be omitted
+            $sourceCurrency = $repository->getAccountCurrency($source);
+            $destCurrency =  $repository->getAccountCurrency($dest);
+            if (
+                $sourceCurrency !== null
+                && $destCurrency !== null
+                && $sourceCurrency->id !== $destCurrency->id
+            ) {
                 $validator->errors()->add('query', (string)trans('validation.invalid_query_currency'));
             }
         }


### PR DESCRIPTION
Changes in this pull request:

- Before validating the currency IDs for source/destination accounts in bulk transaction update action, verify if the result of `AccountRepositoryInterface::getAccountCurrency` is not null

---

Hello,
I'm playing around the Firefly III API willing to clean up my transactions and duplicated expenses accounts after import. With bulk transaction update endpoint I wanted to move all transactions from duplicated account into one particular. However, I was getting an error:

```
[2023-01-14 14:50:38] local.ERROR: Attempt to read property "id" on null {"userId":1,"exception":"[object] (ErrorException(code: 0): Attempt to read property \"id\" on null at /var/www/html/app/Validation/Api/Data/Bulk/ValidatesBulkTransactionQuery.php:71)
```
The validator mentioned in stack calls `AccountRepositoryInterface::getAccountCurrency` for both source and destination account to make sure that the currency of both accounts are same. As I'm doing the update for expense accounts, they don't have any associated currency, so the method returns `null`.

https://github.com/firefly-iii/firefly-iii/blob/4c27bbf06971b45f17cb939ae97e475cb416bf32/app/Repositories/Account/AccountRepository.php#L477-L485

https://github.com/firefly-iii/firefly-iii/blob/4c27bbf06971b45f17cb939ae97e475cb416bf32/config/firefly.php#L222-L231

This pull request is fixing nullability check for the result of calling repository method. 

@JC5
