### PR TITLE
Correct Norwegian translation for auto budgetting

### DIFF
--- a/resources/lang/nb_NO/firefly.php
+++ b/resources/lang/nb_NO/firefly.php
@@ -1694,7 +1694,7 @@ return [
     'transferred_away'                          => 'Overført (borte)',
     'auto_budget_none'                          => 'Ingen automatisk budsjett',
     'auto_budget_reset'                         => 'Angi et fast beløp hver periode',
-    'auto_budget_rollover'                      => 'Angi et fast beløp hver periode',
+    'auto_budget_rollover'                      => 'Legg til et fast beløp hver periode',
     'auto_budget_period_daily'                  => 'Daglig',
     'auto_budget_period_weekly'                 => 'Ukentlig',
     'auto_budget_period_monthly'                => 'Månedlig',


### PR DESCRIPTION
<!--
Before you create a new PR, please consider:

1) Pull requests for the MAIN branch will be closed.
2) DO NOT include translations in your PR. Only English US sentences.

Thanks.
-->

Fixes issue # (if relevant)

Changes in this pull request:

- Changed translation for one of the auto budgetting types in Norwegian. The biggest problem was that the two different types had the same translation. Now they don't. New translation uses the term "Legg til", which means "Add". Original translation was "Angi" which means "Set"
- 
- 

@JC5
