### PR TITLE
feature/api-v2-operations

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,10 @@
 
 declare(strict_types=1);
 
+if (!defined('DATEFORMAT')) {
+    define('DATEFORMAT', '(19|20)[0-9]{2}-?[0-9]{2}-?[0-9]{2}');
+}
+
 /**
  * V2 API route for TransactionSum API endpoints
  * TODO what to do with these routes
@@ -73,6 +77,7 @@ Route::group(
     ],
     static function () {
         Route::get('account/dashboard', ['uses' => 'AccountController@dashboard', 'as' => 'dashboard']);
+        Route::get('account/operations/{accountList}/{start_date}/{end_date}', ['uses' => 'AccountController@operations', 'as' => 'operations'])->where(['start_date' => DATEFORMAT])->where(['end_date' => DATEFORMAT]);
     }
 );
 


### PR DESCRIPTION
## Changes in this pull request:

following https://github.com/firefly-iii/firefly-iii/discussions/6459

- Add Api V2 endpoint: `/account/operations` 
- Copied from Http Controllers
- Tested with API V2 
- Will be used to display the net worth chart with Income vs. Expenses [here](https://github.com/victorbalssa/abacus)
- example:

<img src="https://user-images.githubusercontent.com/12813321/223228036-11a190b8-8c7b-4605-ac00-4791daafd49d.jpeg" width="350px" height="430px">

Thank you so much for this more than stable V6.0.0

@JC5
