### PR TITLE
Fix upload attachment via API

### DIFF
--- a/app/Http/Middleware/AcceptHeaders.php
+++ b/app/Http/Middleware/AcceptHeaders.php
@@ -45,8 +45,8 @@ class AcceptHeaders
     public function handle($request, $next): mixed
     {
         $method       = $request->getMethod();
-        $accepts      = ['application/x-www-form-urlencoded', 'application/json', 'application/vnd.api+json', '*/*'];
-        $contentTypes = ['application/x-www-form-urlencoded', 'application/json', 'application/vnd.api+json'];
+        $accepts      = ['application/x-www-form-urlencoded', 'application/json', 'application/vnd.api+json', 'application/octet-stream', '*/*'];
+        $contentTypes = ['application/x-www-form-urlencoded', 'application/json', 'application/vnd.api+json', 'application/octet-stream'];
         $submitted    = (string)$request->header('Content-Type');
 
 


### PR DESCRIPTION
Fixes issue # (if relevant)

Changes in this pull request:

- Fix upload attachment via API

The `AcceptHeaders` middleware introduced in v6.0 limits the allowed content type of an API call to `application/x-www-form-urlencoded`, `application/json` and `application/vnd.api+json`. A 415 error will be raised for other content types. `POST ​/v1​/attachments​/{id}​/upload` [requires](https://github.com/firefly-iii/api-docs/blob/ed398f903aa12e03eff702455fad7674f1f2e891/firefly-iii-2.0.0-v1.yaml#L4640-L4645) `application/octet-stream`, thus is broken with this middleware.

This PR adds `application/octet-stream` to the allowed list.

@JC5
