### PR TITLE
Rule ConvertToDeposit: fix missing parameter

### DIFF
--- a/app/TransactionRules/Actions/ConvertToDeposit.php
+++ b/app/TransactionRules/Actions/ConvertToDeposit.php
@@ -206,7 +206,7 @@ class ConvertToDeposit implements ActionInterface
 
         // update the source transaction and put in the new revenue ID.
         DB::table('transactions')
-          ->where('transaction_journal_id', '=', )
+          ->where('transaction_journal_id', '=', $journal->id)
           ->where('amount', '<', 0)
           ->update(['account_id' => $opposingAccount->id]);
 


### PR DESCRIPTION

Fixes issue # (if relevant)

Changes in this pull request:

- a minor fix on the ConvertToDeposit, a missing parameter in the where condition.

When the rules triggers, I'm getting this error:

    Internal Firefly III Exception:
    SQLSTATE[22007]:
    Invalid datetime format: 1292 Truncated incorrect DOUBLE value: '=' (Connection: mysql,
    SQL: update `transactions` set `account_id` = 254 where `transaction_journal_id` = = and `amount` < 0
    )

I hope this fix it, I've also checked others ConvertToX rules, but they look good to me.

@JC5
