### PR TITLE
Possibility to force HTTPS scheme by setting environment variable

### DIFF
--- a/.ci/.env.ci
+++ b/.ci/.env.ci
@@ -35,6 +35,10 @@ TZ=Europe/Amsterdam
 # Set it to ** and reverse proxies work just fine.
 TRUSTED_PROXIES=
 
+# Change this to force application to use HTTPS protocol for all routes.
+# Can be useful when for example Firefly is behind a reverse proxy, which does not pass X-Forwarded-Proto, but the app itself is accessible using HTTPS
+FORCE_USE_HTTPS=false
+
 # The log channel defines where your log entries go to.
 # Several other options exist. You can use 'single' for one big fat error log (not recommended).
 # Also available are 'syslog', 'errorlog' and 'stdout' which will log to the system itself.

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,10 @@ TZ=Europe/Amsterdam
 # Set it to ** and reverse proxies work just fine.
 TRUSTED_PROXIES=
 
+# Change this to force application to use HTTPS protocol for all routes.
+# Can be useful when for example Firefly is behind a reverse proxy, which does not pass X-Forwarded-Proto, but the app itself is accessible using HTTPS
+FORCE_USE_HTTPS=false
+
 # The log channel defines where your log entries go to.
 # Several other options exist. You can use 'single' for one big fat error log (not recommended).
 # Also available are 'syslog', 'errorlog' and 'stdout' which will log to the system itself.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -43,6 +43,10 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Schema::defaultStringLength(191);
+        if (true === config('firefly.forceUseHttps')) {
+            URL::forceScheme('https');
+        }
+
         Response::macro('api', function (array $value) {
             $headers = [
                 'Cache-Control' => 'no-store',

--- a/config/firefly.php
+++ b/config/firefly.php
@@ -196,6 +196,7 @@ return [
 
     // web configuration:
     'trusted_proxies'              => env('TRUSTED_PROXIES', ''),
+    'forceUseHttps'                => env('FORCE_USE_HTTPS', false),
     'layout'                       => envNonEmpty('FIREFLY_III_LAYOUT', 'v1'),
 
     // map configuration


### PR DESCRIPTION
Changes in this pull request:

- Possibility to force HTTPS scheme by setting `FORCE_USE_HTTPS` environment variable

I have a Firefly setup, in which Firefly is accessed using HTTPS protocol. However, in private cloud that I'm using, HTTPS offloading happens before request is made to Firefly, and therefore Firefly gets only HTTP traffic. What's also unfortunate, I cannot control reverse-proxy which does the offloading, and the reverse-proxy itself does not set X-Forwarded-Proto header. Therefore, there is no way for me to force Firefly to use HTTPS mode for generating routes.

I used to use 'heroku' environment before (as it was forcing HTTPS under the hood), but since it was removed in 6.0.17 (commit https://github.com/firefly-iii/firefly-iii/commit/3ee5e9aa041c61d71c3e276097a2ba368348908f) I'm no longer able to do that.

Thanks for your awesome project! I'm using it for more that a year, and I really love it! 🙂

@JC5
