### PR TITLE
URL is broken in bills section from menu sidebar

### DIFF
--- a/resources/views/partials/menu-sidebar.twig
+++ b/resources/views/partials/menu-sidebar.twig
@@ -16,7 +16,7 @@
     </li>
 
     <li class="{{ activeRoutePartial('bills') }}">
-        <a href="{{ route('bills.index', false, false) }}">
+        <a href="{{ route('bills.index') }}">
             <em class="fa fa-calendar-o fa-fw"></em>
             <span>{{ 'bills'|_ }}</span>
         </a>


### PR DESCRIPTION

In 6.0.23 version where the URLs were broken caused by @JC5 :)
I noticed that the bills section in menu sidebar had also the bug, so I fixed removing other parameters.

@JC5
