### PR TITLE
Hide duplicated webhook create button

### DIFF
--- a/resources/assets/js/components/webhooks/Index.vue
+++ b/resources/assets/js/components/webhooks/Index.vue
@@ -80,7 +80,7 @@
             </tbody>
           </table>
 
-          <div style="padding:8px;">
+          <div v-if="webhooks.length > 0" style="padding:8px;">
             <a href="webhooks/create" class="btn btn-success"><span class="fa fa-plus fa-fw"></span>{{ $t('firefly.create_new_webhook') }}</a>
           </div>
         </div>


### PR DESCRIPTION
On the webhooks index page there are two "create new webhook" buttons. One above and one below the table listing the webhooks. When there are no webhooks both buttons are right next to each other which looks kind of like a mistake.

Changes in this pull request:
- Hide duplicated webhook create button when there are no webhooks

Empty table before:
![before-empty](https://github.com/firefly-iii/firefly-iii/assets/16998890/40436978-a581-45d4-b8b8-2b04c6ba1a5b)
Empty table after:
![after-empty](https://github.com/firefly-iii/firefly-iii/assets/16998890/a805d351-36ba-435f-ba75-edf18625a959)

<details>
  <summary>With existing webhooks (before and after):</summary>
  <img src="https://github.com/firefly-iii/firefly-iii/assets/16998890/c768dfbc-0a6c-4a27-9690-3a22af6bb242">
</details>

@JC5