### PR TITLE
increase update check timeout from ~3s to ~10s

### DIFF
--- a/app/Services/FireflyIIIOrg/Update/UpdateRequest.php
+++ b/app/Services/FireflyIIIOrg/Update/UpdateRequest.php
@@ -86,7 +86,7 @@ class UpdateRequest implements UpdateRequestInterface
                 'headers' => [
                     'User-Agent' => sprintf('FireflyIII/%s/%s', config('firefly.version'), $channel),
                 ],
-                'timeout' => 3.1415,
+                'timeout' => 9.4245,
             ];
             $res     = $client->request('GET', $url, $options);
         } catch (GuzzleException $e) {


### PR DESCRIPTION
## Context
I self host firefly on my own hardware, and for a long while I've been seeing the "connection timed out after 3141 milliseconds" when firefly checks for an update. I thought the internet in the container was broke however after curling the update endpoint inside the container, i realised that the shorter curl timeout was causing the update check to timeout.

Therefore i have increased the timeout from short 3 seconds to a moderate 10s.

(i did observe the original timeout was pi, so I increased it by a multiple of 3 :P )

## Changes in this pull request:

- increases update check timeout from 3s (π) to 10s (3*π)


@JC5
