### PR TITLE
Fixed downlodWebhok function after adding a new webhook.

### DIFF
--- a/resources/assets/js/components/webhooks/Index.vue
+++ b/resources/assets/js/components/webhooks/Index.vue
@@ -122,7 +122,7 @@ export default {
       webhook.show_secret = !webhook.show_secret;
     },
     downloadWebhooks: function (page) {
-      axios.get("/api/v1/webhooks?page=" + page).then((response) => {
+      axios.get("./api/v1/webhooks?page=" + page).then((response) => {
         for (let i in response.data.data) {
           if (response.data.data.hasOwnProperty(i)) {
             let current = response.data.data[i];


### PR DESCRIPTION
Fixes issue:
After adding a new webhook the showed list is empty because the relative path is wrong in case of subfolder on main domain.

Ex:
the domain where fireflyIII is my-site.net/public
After adding a new webook the list will retrieve from my-site.net and not from my-site.net/public

Changes in this pull request:

- Added "." as currenct directory othrwise we get a bad relative path.

@JC5
