### PR TITLE
Adding regexp to description trigger

### DIFF
--- a/app/Helpers/Collector/GroupCollector.php
+++ b/app/Helpers/Collector/GroupCollector.php
@@ -1018,6 +1018,42 @@ class GroupCollector implements GroupCollectorInterface
     }
 
     /**
+     * Use regexs to filter descriptions.
+     *
+     * @param array $array
+     *
+     * @return GroupCollectorInterface
+     */
+    public function setRegexs(array $array): GroupCollectorInterface
+    {
+        if (0 === count($array)) {
+            return $this;
+        }
+        $this->query->where(
+            static function (EloquentBuilder $q) use ($array) {
+                $q->where(
+                    static function (EloquentBuilder $q1) use ($array) {
+                        foreach ($array as $word) {
+                            $keyword = sprintf('%s', $word);
+                            $q1->where('transaction_journals.description', 'regexp', $keyword);
+                        }
+                    }
+                );
+                $q->orWhere(
+                    static function (EloquentBuilder $q2) use ($array) {
+                        foreach ($array as $word) {
+                            $keyword = sprintf('%s', $word);
+                            $q2->where('transaction_groups.title', 'regexp', $keyword);
+                        }
+                    }
+                );
+            }
+        );
+
+        return $this;
+    }
+
+    /**
      * Limit the search to one specific transaction group.
      *
      * @param TransactionGroup $transactionGroup

--- a/app/Helpers/Collector/GroupCollectorInterface.php
+++ b/app/Helpers/Collector/GroupCollectorInterface.php
@@ -1256,6 +1256,15 @@ interface GroupCollectorInterface
     public function setSearchWords(array $array): GroupCollectorInterface;
 
     /**
+     * Use regexs to filter descriptions.
+     *
+     * @param array $array
+     *
+     * @return GroupCollectorInterface
+     */
+    public function setRegexs(array $array): GroupCollectorInterface;
+
+    /**
      * @param string $sepaCT
      *
      * @return GroupCollectorInterface

--- a/app/Support/Search/OperatorQuerySearch.php
+++ b/app/Support/Search/OperatorQuerySearch.php
@@ -79,6 +79,7 @@ class OperatorQuerySearch implements SearchInterface
     private TagRepositoryInterface      $tagRepository;
     private array                       $validOperators;
     private array                       $words;
+    private array                       $regexs;
 
     /**
      * OperatorQuerySearch constructor.
@@ -91,6 +92,7 @@ class OperatorQuerySearch implements SearchInterface
         $this->operators          = new Collection();
         $this->page               = 1;
         $this->words              = [];
+        $this->regexs              = [];
         $this->prohibitedWords    = [];
         $this->invalidOperators   = [];
         $this->limit              = 25;
@@ -168,6 +170,7 @@ class OperatorQuerySearch implements SearchInterface
 
         $this->collector->setSearchWords($this->words);
         $this->collector->excludeSearchWords($this->prohibitedWords);
+        $this->collector->setRegexs($this->regexs);
     }
 
     /**
@@ -552,6 +555,9 @@ class OperatorQuerySearch implements SearchInterface
                 break;
             case '-description_is':
                 $this->collector->descriptionIsNot($value);
+                break;
+            case 'description_regex':
+                $this->regexs[] = $value;
                 break;
                 //
                 // currency

--- a/config/search.php
+++ b/config/search.php
@@ -39,6 +39,7 @@ return [
         'description_contains'            => ['alias' => false, 'needs_context' => true,],
         'description_ends'                => ['alias' => false, 'needs_context' => true,],
         'description_starts'              => ['alias' => false, 'needs_context' => true,],
+        'description_regex'               => ['alias' => false, 'needs_context' => true,],
         'notes_is'                        => ['alias' => false, 'needs_context' => true,],
         'notes_are'                       => ['alias' => true, 'alias_for' => 'notes_is', 'needs_context' => true,],
         'notes_contains'                  => ['alias' => false, 'needs_context' => true,],
@@ -234,6 +235,5 @@ return [
         'sepa_ct_is'                      => ['alias' => false, 'needs_context' => true],
         'no_external_id'                  => ['alias' => false, 'needs_context' => false],
         'any_external_id'                 => ['alias' => false, 'needs_context' => false],
-
     ],
 ];

--- a/resources/lang/ca_ES/firefly.php
+++ b/resources/lang/ca_ES/firefly.php
@@ -879,6 +879,7 @@ return [
     'rule_trigger_description_contains'                   => 'La descripció conté ":trigger_value"',
     'rule_trigger_description_is_choice'                  => 'La descripció és..',
     'rule_trigger_description_is'                         => 'La descripció és ":trigger_value"',
+    'rule_trigger_description_regex'                      => 'La descripció compleix l\'expressió regular ":trigger_value"',
     'rule_trigger_date_on_choice'                         => 'La data de la transacció és..',
     'rule_trigger_date_on'                                => 'La data de la transacció és ":trigger_value"',
     'rule_trigger_date_before_choice'                     => 'La data de la transacció és anterior a..',

--- a/resources/lang/en_GB/firefly.php
+++ b/resources/lang/en_GB/firefly.php
@@ -879,6 +879,7 @@ return [
     'rule_trigger_description_contains'                   => 'Description contains ":trigger_value"',
     'rule_trigger_description_is_choice'                  => 'Description is..',
     'rule_trigger_description_is'                         => 'Description is ":trigger_value"',
+    'rule_trigger_description_regex'                      => 'Descriptions validates regexp ":trigger_value"',
     'rule_trigger_date_on_choice'                         => 'Transaction date is..',
     'rule_trigger_date_on'                                => 'Transaction date is ":trigger_value"',
     'rule_trigger_date_before_choice'                     => 'Transaction date is before..',


### PR DESCRIPTION
I wanted a trigger which assign a category if:
- movement category is empty
- description contains "lorem" or "ipsum

I know it is an edge case, so in order to not complicate things for other uses, adding regexp allow a solution.

I read about including translations after committing it, I hope it isn't a problem.

First merge request I have made, sorry if I missed something. And now I am a symfony developer, I hope my code is ok.