### PR TITLE
Update outdated documentation URLs in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,7 +78,7 @@ PAPERTRAIL_HOST=
 PAPERTRAIL_PORT=
 
 # Database credentials. Make sure the database exists. I recommend a dedicated user for Firefly III
-# For other database types, please see the FAQ: https://docs.firefly-iii.org/firefly-iii/faq/self-hosted/#i-want-to-use-sqlite
+# For other database types, please see the FAQ: https://docs.firefly-iii.org/references/faq/install/#i-want-to-use-sqlite
 # If you use Docker or similar, you can set these variables from a file by appending them with _FILE
 # Use "pgsql" for PostgreSQL
 # Use "mysql" for MySQL and MariaDB.
@@ -150,7 +150,7 @@ COOKIE_SECURE=false
 COOKIE_SAMESITE=lax
 
 # If you want Firefly III to email you, update these settings
-# For instructions, see: https://docs.firefly-iii.org/firefly-iii/advanced-installation/email/#email
+# For instructions, see: https://docs.firefly-iii.org/how-to/firefly-iii/advanced/notifications/#email
 # If you use Docker or similar, you can set these variables from a file by appending them with _FILE
 MAIL_MAILER=log
 MAIL_HOST=null
@@ -214,7 +214,7 @@ VALID_URL_PROTOCOLS=
 # - 'web' (default, uses built in DB)
 # - 'remote_user_guard' for Authelia etc
 # Read more about these settings in the documentation.
-# https://docs.firefly-iii.org/firefly-iii/advanced-installation/authentication
+# https://docs.firefly-iii.org/how-to/firefly-iii/advanced/authentication/
 #
 # LDAP is no longer supported :(
 #
@@ -269,7 +269,7 @@ ALLOW_WEBHOOKS=false
 # 1. Set this token to any 32-character value (this is important!).
 # 2. Use this token in the cron URL instead of a user's command line token that you can find in /profile
 #
-# For more info: https://docs.firefly-iii.org/firefly-iii/advanced-installation/cron/
+# For more info: https://docs.firefly-iii.org/how-to/firefly-iii/advanced/cron/
 #
 # You can set this variable from a file by appending it with _FILE
 #


### PR DESCRIPTION
Changes in this pull request:

- Update outdated documentation URLs in .env.example

![image](https://github.com/firefly-iii/firefly-iii/assets/322159/4db81693-1760-4fa1-9975-ecb19a35b2fa)

@JC5
