### PR TITLE
Update favicons.twig

### DIFF
--- a/resources/views/partials/favicons.twig
+++ b/resources/views/partials/favicons.twig
@@ -1,7 +1,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png?v=3e8AboOwbd">
 <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png?v=3e8AboOwbd">
-<link rel="manifest" href="manifest.webmanifest?v=3e8AboOwbd">
+<link rel="manifest" href="manifest.webmanifest?v=3e8AboOwbd" crossorigin="use-credentials">
 <link rel="mask-icon" href="safari-pinned-tab.svg" color="#3c8dbc">
 <link rel="shortcut icon" href="favicon.ico?v=3e8AboOwbd">
 <meta name="apple-mobile-web-app-title" content="Firefly III">


### PR DESCRIPTION
Changes in this pull request:

When I use firefly-iii behind oauth2-proxy which handles authentication, it sets a cookie.
With this cookie, requests are forwarded to the firefly-ii.
Everything works fine, except for the manifest.json, where the browser doesn't send the cookie and you end up with an error (CORS).

The solution is to add the crossorigin="use-credentials" attribute to the tag:

<link rel="manifest" href="/manifest.json" crossorigin="use-credentials">

Documentation :
[crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin)
[link attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-crossorigin)

@JC5
