### PR TITLE
Added unix_socket to pgsql

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -100,6 +100,7 @@ return [
             'database'    => envNonEmpty('DB_DATABASE', $database),
             'username'    => envNonEmpty('DB_USERNAME', $username),
             'password'    => env('DB_PASSWORD', $password),
+            'unix_socket' => env('DB_SOCKET', ''),
             'charset'     => 'utf8',
             'prefix'      => '',
             'search_path' => envNonEmpty('PGSQL_SCHEMA', 'public'),


### PR DESCRIPTION
Postgres serves over TCP sockets and UNIX sockets. Some users may prefer UNIX sockets because they can use their UNIX user as authentication to the database. Firefly-iii already supports MySQL over UNIX sockets and a very small change will allow Firefly-iii to support Postgres over UNIX sockets.

@JC5
