### PR TITLE
Fix `Division error by zero` in budget views

### DIFF
--- a/resources/views/budgets/index.twig
+++ b/resources/views/budgets/index.twig
@@ -324,7 +324,7 @@
                                                         {# the amount left is automatically calculated. #}
                                                         {{ formatAmountBySymbol(spentInfo.spent + budgetLimit.amount, spentInfo.currency_symbol, spentInfo.currency_decimal_places) }}
                                                         {% if spentInfo.spent + budgetLimit.amount > 0 %}
-                                                            ({{ formatAmountBySymbol((spentInfo.spent + budgetLimit.amount) / activeDaysLeft, spentInfo.currency_symbol, spentInfo.currency_decimal_places) }})
+                                                            ({{ formatAmountBySymbol((0 is same as(activeDaysLeft)) ? (spentInfo.spent + budgetLimit.amount) : (spentInfo.spent + budgetLimit.amount) / activeDaysLeft, spentInfo.currency_symbol, spentInfo.currency_decimal_places) }})
                                                         {% else %}
                                                             ({{ formatAmountBySymbol(0, spentInfo.currency_symbol, spentInfo.currency_decimal_places) }})
                                                         {% endif %}


### PR DESCRIPTION
<!--
Before you create a new PR, please consider:

1) Pull requests for the MAIN branch will be closed.
2) DO NOT include translations in your PR. Only English US sentences.

Thanks.
-->

Fixes issue #8732  (if relevant)

Changes in this pull request:

- Fix `Division error by zero` in budget views
-
-

![image](https://github.com/firefly-iii/firefly-iii/assets/43638783/bc5f0a95-0c84-4319-bcbb-22263479f6cf)


In that issue (#8732), you only fix "Left to Spend" box in dashboard (commit: https://github.com/firefly-iii/firefly-iii/commit/3268019d0cf67b7c726b574d89a54c81c0c2e417). But the budget views itself hasn't been fixed. In this PR i have provide fix for that, i implemented your code from commit https://github.com/firefly-iii/firefly-iii/commit/3268019d0cf67b7c726b574d89a54c81c0c2e417 into budget views. If there is any mistake, i apologies, i'm not good with PHP language. I have tested this locally in my server and it works without error

@JC5
