### PR TITLE
Set date to now when cloning journal

### DIFF
--- a/app/Services/Internal/Update/GroupCloneService.php
+++ b/app/Services/Internal/Update/GroupCloneService.php
@@ -54,7 +54,7 @@ class GroupCloneService
     {
         $newJournal                       = $journal->replicate();
         $newJournal->transaction_group_id = $newGroup->id;
-        $newJournal->date                 = today(config('app.timezone'));
+        $newJournal->date                 = now();
         $newJournal->save();
 
         foreach ($journal->transactions as $transaction) {


### PR DESCRIPTION
<!--
Before you create a new PR, please consider:

1) Pull requests for the MAIN branch will be closed.
2) DO NOT include translations in your PR. Only English US sentences.

Thanks.
-->

Fixes issue # None

Changes in this pull request:

- Set date to now when cloning journal

Commit https://github.com/firefly-iii/firefly-iii/commit/c979cfcd89457188976b2a9df04b22c02fa26e88 change the date from `Carbon::now()` to `today(config('app.timezone'))` when cloning journal

I believe when we clone a transaction, we hope the date to be now, not the start of today.

@JC5
