### PR TITLE
Add notes to transaction audit report

### DIFF
--- a/app/Generator/Report/Audit/MonthReportGenerator.php
+++ b/app/Generator/Report/Audit/MonthReportGenerator.php
@@ -88,6 +88,7 @@ class MonthReportGenerator implements ReportGeneratorInterface
             'due_date',
             'payment_date',
             'invoice_date',
+            'notes',
         ];
 
         try {
@@ -160,6 +161,7 @@ class MonthReportGenerator implements ReportGeneratorInterface
             $journals[$index]['due_date']       = $journalRepository->getMetaDateById($journal['transaction_journal_id'], 'due_date');
             $journals[$index]['payment_date']   = $journalRepository->getMetaDateById($journal['transaction_journal_id'], 'payment_date');
             $journals[$index]['invoice_date']   = $journalRepository->getMetaDateById($journal['transaction_journal_id'], 'invoice_date');
+            $journals[$index]['notes']          = $journalRepository->getMetaDateById($journal['transaction_journal_id'], 'notes');
         }
         $locale            = app('steam')->getLocale();
 

--- a/resources/views/reports/partials/journals-audit.twig
+++ b/resources/views/reports/partials/journals-audit.twig
@@ -29,6 +29,7 @@
         <th class="hide-due_date">{{ trans('list.due_date') }}</th>
         <th class="hide-payment_date">{{ trans('list.payment_date') }}</th>
         <th class="hide-invoice_date">{{ trans('list.invoice_date') }}</th>
+        <th class="hide-notes">{{ trans('list.notes') }}</th>
 
     </tr>
     </thead>
@@ -174,6 +175,11 @@
             <td class="hide-invoice_date">
                 {% if null != journal.invoice_date %}
                     {{ journal.invoice_date.isoFormat(monthAndDayFormat) }}
+                {% endif %}
+            </td>
+            <td class="hide-notes">
+                {% if null != journal.notes %}
+                    {{ journal.notes }}
                 {% endif %}
             </td>
         </tr>


### PR DESCRIPTION
This PR fixes issue #8531.

Changes in this pull request:
- Added on the `Home > Reports > Transaction history overview` page
  - new `Notes` option
  - new `Notes` column
- No other changes

Please see what it looks like in the screenshot 👇
<img width="1127" alt="Transaction history overview" src="https://github.com/firefly-iii/firefly-iii/assets/947620/3cbb7094-13df-47e5-9b4a-e168ddf1cb86">

@JC5 Please confirm that's all we need for the new feature.