### PR TITLE
bcadd (string) fixes for SQLite float values

### DIFF
--- a/app/Support/Models/AccountBalanceCalculator.php
+++ b/app/Support/Models/AccountBalanceCalculator.php
@@ -120,13 +120,13 @@ class AccountBalanceCalculator
 
             // first create for normal currency:
             $entry               = $this->getAccountBalanceByAccount($account, $transactionCurrency);
-            $entry->balance      = bcadd((string) $entry->balance, $sumAmount);
+            $entry->balance      = bcadd((string) $entry->balance, (string) $sumAmount);
             $entry->save();
 
             // then do foreign amount, if present:
             if ($foreignCurrency > 0) {
                 $entry          = $this->getAccountBalanceByAccount($account, $foreignCurrency);
-                $entry->balance = bcadd((string) $entry->balance, $sumForeignAmount);
+                $entry->balance = bcadd((string) $entry->balance, (string) $sumForeignAmount);
                 $entry->save();
             }
         }
@@ -185,8 +185,8 @@ class AccountBalanceCalculator
             $sumForeignAmount                        = '' === $sumForeignAmount ? '0' : $sumForeignAmount;
 
             // new amounts:
-            $amounts[$account][$transactionCurrency] = bcadd($amounts[$account][$transactionCurrency] ?? '0', $sumAmount);
-            $amounts[$account][$foreignCurrency]     = bcadd($amounts[$account][$foreignCurrency] ?? '0', $sumForeignAmount);
+            $amounts[$account][$transactionCurrency] = bcadd((string) $amounts[$account][$transactionCurrency] ?? '0', (string) $sumAmount ?? '0');
+            $amounts[$account][$foreignCurrency]     = bcadd((string) $amounts[$account][$foreignCurrency] ?? '0', (string) $sumForeignAmount ?? '0');
 
             // first create for normal currency:
             $entry                                   = self::getAccountBalanceByJournal('balance_after_journal', $account, $journalId, $transactionCurrency);


### PR DESCRIPTION
As a brand new user to Firefly, after just setting up first install - using SQLite as database, creating my first user and submitting my first bank balance, I immediately encountered a crash with the:

`Argument #2 ($num2) must be of type string, float given` error

There is not a specific PR that I am aware of for this particular one but there are a few related issues. After looking at how they were fixed I see that the float values were just casted to strings to strings to make them compatible with bcadd().

See similar previous issues here: https://github.com/firefly-iii/firefly-iii/issues/6260 https://github.com/firefly-iii/firefly-iii/issues/8907

I implemented the same fix. Reinstalled my Firefly again from scratch, followed same process, created new user + new account with balance and the crash no longer occurs.