### PR TITLE
add icon for delete action

### DIFF
--- a/resources/views/accounts/reconcile/transactions.twig
+++ b/resources/views/accounts/reconcile/transactions.twig
@@ -63,6 +63,8 @@
                 <div class="btn-group btn-group-xs">
                     <a href="{{ route('transactions.edit', [journal.transaction_group_id]) }}" class="btn btn-xs btn-default"><span
                                 class="fa fa-fw fa-pencil"></span></a>
+                    <a href="{{ route('transactions.delete', [journal.transaction_group_id]) }}" class="btn btn-danger"><span
+                                class="fa fa-trash"></span></a>
                 </div>
 
             </td>


### PR DESCRIPTION
in workflow of reconciling account, sometimes a record needs to be deleted (i.e. in event of a duplicated transaction from an import or error) and this change adds an icon to the delete route

<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue # (if relevant).

Changes in this pull request:

-
-
-

@JC5
