### PR TITLE
Add about tests

### DIFF
--- a/tests/integration/Api/About/AboutControllerTest.php
+++ b/tests/integration/Api/About/AboutControllerTest.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * AboutControllerTest.php
+ * Copyright (c) 2021 james@firefly-iii.org
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\integration\Api\About;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\integration\TestCase;
+
+/**
+ * Class AboutControllerTest
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class AboutControllerTest extends TestCase
+{
+    use RefreshDatabase;
+    private $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (!isset($this->user))
+            $this->user = $this->createAuthenticatedUser();
+        $this->actingAs($this->user);
+    }
+
+    public function testGivenAuthenticatedRequestReturnsSystemInformation(): void
+    {
+        $response = $this->getJson(route('api.v1.about.index'));
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'data' => [
+                'version',
+                'api_version',
+                'php_version',
+                'os',
+                'driver'
+            ],
+        ]);
+    }
+
+    public function testGivenAuthenticatedRequestReturnsUserInformation(): void
+    {
+        $response = $this->getJson(route('api.v1.about.user'));
+
+        $response->assertOk();
+        $response->assertJson(fn(AssertableJson $json) =>
+            $json
+                ->where('data.attributes.email', $this->user->email)
+                ->where('data.attributes.role', $this->user->role)
+        );
+    }
+}

--- a/tests/integration/TestCase.php
+++ b/tests/integration/TestCase.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Tests\integration;
 
+use FireflyIII\User;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Tests\integration\Traits\CollectsValues;
 
@@ -47,5 +48,13 @@ abstract class TestCase extends BaseTestCase
             'one year'     => ['1Y'],
             'custom range' => ['custom'],
         ];
+    }
+
+    protected function createAuthenticatedUser(): User
+    {
+        return User::create([
+            'email' => 'test@email.com',
+            'password' => 'password',
+        ]);
     }
 }


### PR DESCRIPTION
Changes in this pull request:

- Added simple tests for about endpoints in `v1` api.
- I've added a method for creating an authenticated user in `tests/integration/TestCase.php`, as I think this will most likely be used in some other tests, by me and @tasnim0tantawi.

@JC5
