### PR TITLE
Add  test cases for Api\V1\Controllers\Autocomplete\BillController & BudgetController

### DIFF
--- a/tests/integration/Api/Autocomplete/BillControllerTest.php
+++ b/tests/integration/Api/Autocomplete/BillControllerTest.php
@@ -1,0 +1,157 @@
+<?php
+/*
+ * BillControllerTest.php
+ * Copyright (c) 2024 tasnim0tantawi
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\integration\Api\Autocomplete;
+
+use FireflyIII\Models\Bill;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\integration\TestCase;
+use FireflyIII\User;
+use FireflyIII\Models\UserGroup;
+
+/**
+ * Class BillControllerTest
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class BillControllerTest extends TestCase {
+    /**
+     * @covers \FireflyIII\Api\V1\Controllers\Autocomplete\BillController
+     */
+    use RefreshDatabase;
+
+    private function createAuthenticatedUser(): User {
+        $userGroup = UserGroup::create(['title' => 'Test Group']);
+
+        return User::create([
+            'email' => 'test@email.com',
+            'password' => 'password',
+            'user_group_id' => $userGroup->id,
+            ]);
+        }
+
+    private function createTestBills(int $count, User $user): void {
+        for ($i = 1; $i <= $count; $i++) {
+            $bill = Bill::create([
+                'user_id' => $user->id,
+                'name' => 'Bill ' . $i,
+                'user_group_id' => $user->user_group_id,
+                'amount_min' => rand(1, 100), // random amount
+                'amount_max' => rand(101, 200), // random amount
+                'match' => 'MIGRATED_TO_RULES',
+                'date' => '2024-01-01',
+                'repeat_freq' => 'monthly',
+                'automatch' => 1,
+                
+            ]);
+        }
+    }
+    
+
+    public function testGivenAnUnauthenticatedRequestWhenCallingTheBillsEndpointThenReturns401HttpCode(): void {
+        // test API
+        $response = $this->get(route('api.v1.autocomplete.bills'), ['Accept' => 'application/json']);
+        $response->assertStatus(401);
+        $response->assertHeader('Content-Type', 'application/json');
+        $response->assertContent('{"message":"Unauthenticated","exception":"AuthenticationException"}');
+    }
+    
+    public function testGivenAuthenticatedRequestWhenCallingTheBillsEndpointThenReturns200HttpCode(): void
+    {
+        // act as a user
+        $user = $this->createAuthenticatedUser();
+        $this->actingAs($user);
+
+        $response = $this->get(route('api.v1.autocomplete.bills'), ['Accept' => 'application/json']);
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/json');
+
+    }
+
+    public function testGivenAuthenticatedRequestWhenCallingTheBillsEndpointThenReturnsBills(): void
+    {
+        $user = $this->createAuthenticatedUser();
+        $this->actingAs($user);
+
+        $this->createTestBills(5, $user);
+        $response = $this->get(route('api.v1.autocomplete.bills'), ['Accept' => 'application/json']);
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/json');
+        $response->assertJsonCount(5);
+        $response->assertJsonFragment(['name' => 'Bill 1']);
+        $response->assertJsonStructure([
+            '*' => [
+                'id',
+                'name',
+                'active'
+            ]
+        ]);
+
+    }
+
+    public function testGivenAuthenticatedRequestWhenCallingTheBillsEndpointWithQueryThenReturnsBillsWithLimit(): void
+    {
+        $user = $this->createAuthenticatedUser();
+        $this->actingAs($user);
+
+        $this->createTestBills(5, $user);
+        $response = $this->get(route('api.v1.autocomplete.bills', [
+            'query' => 'Bill',
+            'limit' => 3
+        ]), ['Accept' => 'application/json']);
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/json');
+        $response->assertJsonCount(3);
+        $response->assertJsonFragment(['name' => 'Bill 1']);
+        $response->assertJsonStructure([
+            '*' => [
+                'id',
+                'name',
+                'active'
+            ]
+        ]);
+    
+    }
+
+    public function testGivenAuthenticatedRequestWhenCallingTheBillsEndpointWithQueryThenReturnsBillsThatMatchQuery(): void
+    {
+        $user = $this->createAuthenticatedUser();
+        $this->actingAs($user);
+
+        $this->createTestBills(20, $user);
+        $response = $this->get(route('api.v1.autocomplete.bills', [
+            'query' => 'Bill 1',
+            'limit' => 20,
+        ]), ['Accept' => 'application/json']);
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/json');
+        // Bill 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 (11)
+        $response->assertJsonCount(11);
+        $response->assertJsonMissing(['name' => 'Bill 2']);
+    }
+    
+}

--- a/tests/integration/Api/Autocomplete/BudgetControllerTest.php
+++ b/tests/integration/Api/Autocomplete/BudgetControllerTest.php
@@ -1,0 +1,140 @@
+<?php
+/*
+ * BudgetControllerTest.php
+ * Copyright (c) 2024 tasnim0tantawi
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\integration\Api\Autocomplete;
+
+use FireflyIII\Models\Budget;
+use FireflyIII\Models\UserGroup;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\integration\TestCase;
+use FireflyIII\User;
+
+/**
+ * Class BudgetControllerTest
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class BudgetControllerTest extends TestCase {
+    /**
+     * @covers \FireflyIII\Api\V1\Controllers\Autocomplete\BudgetController
+     */
+    use RefreshDatabase;
+
+    private function createAuthenticatedUser(): User {
+        $userGroup = UserGroup::create(['title' => 'Test Group']);
+
+        return User::create([
+            'email' => 'test@email.com',
+            'password' => 'password',
+            'user_group_id' => $userGroup->id,
+            ]);
+        }
+
+    private function createTestBudgets(int $count, User $user): void {
+        for ($i = 1; $i <= $count; $i++) {
+            $budget = Budget::create([
+                'user_id' => $user->id,
+                'name' => 'Budget ' . $i,
+                'user_group_id' => $user->user_group_id,
+                'active' => 1,
+            ]);
+        }
+    }
+    
+
+    public function testGivenAnUnauthenticatedRequestWhenCallingTheBudgetsEndpointThenReturns401HttpCode(): void {
+        // test API
+        $response = $this->get(route('api.v1.autocomplete.budgets'), ['Accept' => 'application/json']);
+        $response->assertStatus(401);
+        $response->assertHeader('Content-Type', 'application/json');
+        $response->assertContent('{"message":"Unauthenticated","exception":"AuthenticationException"}');
+    }
+    
+    public function testGivenAuthenticatedRequestWhenCallingTheBudgetsEndpointThenReturns200HttpCode(): void
+    {
+        // act as a user
+        $user = $this->createAuthenticatedUser();
+        $this->actingAs($user);
+
+        $response = $this->get(route('api.v1.autocomplete.budgets'), ['Accept' => 'application/json']);
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/json');
+
+    }
+
+    public function testGivenAuthenticatedRequestWhenCallingTheBudgetsEndpointThenReturnsBudgets(): void
+    {
+        $user = $this->createAuthenticatedUser();
+        $this->actingAs($user);
+
+        $this->createTestBudgets(5, $user);
+        $response = $this->get(route('api.v1.autocomplete.budgets'), ['Accept' => 'application/json']);
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/json');
+        $response->assertJsonCount(5);
+        $response->assertJsonFragment(['name' => 'Budget 1']);
+          $response->assertJsonStructure([
+            '*' => [
+                'id',
+                'name',
+            ],
+        ]);
+    }
+
+    public function testGivenAuthenticatedRequestWhenCallingTheBudgetsEndpointWithQueryThenReturnsBudgetsWithLimit(): void
+    {
+        $user = $this->createAuthenticatedUser();
+        $this->actingAs($user);
+
+        $this->createTestBudgets(5, $user);
+        $response = $this->get(route('api.v1.autocomplete.budgets', [
+            'query' => 'Budget',
+            'limit' => 3
+        ]), ['Accept' => 'application/json']);
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/json');
+        $response->assertJsonCount(3);
+    }
+
+    public function testGivenAuthenticatedRequestWhenCallingTheBudgetsEndpointWithQueryThenReturnsBudgetsThatMatchQuery(): void
+    {
+        $user = $this->createAuthenticatedUser();
+        $this->actingAs($user);
+
+        $this->createTestBudgets(20, $user);
+        $response = $this->get(route('api.v1.autocomplete.budgets', [
+            'query' => 'Budget 1',
+            'limit' => 20,
+        ]), ['Accept' => 'application/json']);
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/json');
+        // Budget 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 (11)
+        $response->assertJsonCount(11);
+        $response->assertJsonMissing(['name' => 'Budget 2']);
+    }
+    
+}


### PR DESCRIPTION
Add test cases for `Api\V1\Controllers\Autocomplete\BillController.php`

![image](https://github.com/user-attachments/assets/488e4413-9f24-4b40-af32-f6a5013a57be)

---

Add test cases for `Api\V1\Controllers\Autocomplete\BudgetController.php`
![image](https://github.com/user-attachments/assets/e65bf7ae-fc3f-4f13-b099-251e091c04f0)

They are kind of similar, so I felt no need for 2 separate pull requests.

@JC5
