### PR TITLE
Fix webhook index page when Firefly is not served at root

### DIFF
--- a/resources/assets/v1/src/components/webhooks/Index.vue
+++ b/resources/assets/v1/src/components/webhooks/Index.vue
@@ -122,7 +122,7 @@ export default {
       webhook.show_secret = !webhook.show_secret;
     },
     downloadWebhooks: function (page) {
-      axios.get("/api/v1/webhooks?page=" + page).then((response) => {
+      axios.get("./api/v1/webhooks?page=" + page).then((response) => {
         for (let i in response.data.data) {
           if (response.data.data.hasOwnProperty(i)) {
             let current = response.data.data[i];


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->

Changes in this pull request:

When Firefly is not served at the root path, the webhook index page breaks, not listing the webhooks.

![image](https://github.com/user-attachments/assets/15ad182c-c8f7-4003-9dd3-ecc3671c5ea5)

I added a "." to the URL, like other components do.

Since the solution was simple, I did not open an issue first. 

@JC5
