### PR TITLE
Transaction Model: explicitly cast decimal to string

### DIFF
--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -54,6 +54,8 @@ class Transaction extends Model
             'bill_name_encrypted' => 'boolean',
             'reconciled'          => 'boolean',
             'balance_dirty'       => 'boolean',
+            'balance_before'      => 'string'
+            'balance_after'       => 'string'
             'date'                => 'datetime',
         ];
 


### PR DESCRIPTION
Laravel defers to PDO & the underlying database as to what type decimals are cast as. When using sqlite text that match a float will be returned as a float, while mySql always returns a string for a decimal. This leads to crashes with sqlite while trying to import tranansactions. (It does not happen every transaction, only when the balance{before,after} coming from the database is floatable)

`FireflyIII\Support\Models\AccountBalanceCalculator::getLatestBalance(): Return value must be of type string, float returned.`

Fixes: #9458

I figured this out a few days ago, and finally had the time to PR, and saw someone beat me to report the issue. This should be a better & more permanent fix than typecasting the return value, which i only saw you implemented after i opened the pr.

<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue # (if relevant).

Changes in this pull request:

-
-
-

@JC5
