### PR TITLE
fix: include foreign_amount in transaction sum calculation

### DIFF
--- a/app/Console/Commands/Integrity/ReportSum.php
+++ b/app/Console/Commands/Integrity/ReportSum.php
@@ -58,7 +58,7 @@ class ReportSum extends Command
 
         /** @var User $user */
         foreach ($userRepository->all() as $user) {
-            $sum = (string)$user->transactions()->sum('amount');
+            $sum = (string)$user->transactions()->selectRaw('SUM(amount) + SUM(foreign_amount) as total')->value('total');
             if (!is_numeric($sum)) {
                 $message = sprintf('Error: Transactions for user #%d (%s) have an invalid sum ("%s").', $user->id, $user->email, $sum);
                 $this->friendlyError($message);


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue #9482.

Changes in this pull request:

- Updated the transaction sum calculation to account for both `amount` and `foreign_amount` fields. This ensures that transfers involving foreign currencies are correctly included in the `reportSum` check.

@JC5
