### PR TITLE
fix: set dest foreign_amount and foreign_currency_id for foreign transfers

### DIFF
--- a/app/Services/Internal/Update/JournalUpdateService.php
+++ b/app/Services/Internal/Update/JournalUpdateService.php
@@ -721,6 +721,8 @@ class JournalUpdateService
                 Log::debug('Switch amounts, store in amount and not foreign_amount');
                 $dest->transaction_currency_id = $foreignCurrency->id;
                 $dest->amount                  = app('steam')->positive($foreignAmount);
+                $dest->foreign_amount          = app('steam')->positive($source->amount);
+                $dest->foreign_currency_id     = $source->transaction_currency_id;
             }
             if (TransactionType::TRANSFER !== $this->transactionJournal->transactionType->type) {
                 $dest->foreign_currency_id = $foreignCurrency->id;


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue #9487.

Changes in this pull request:

- This PR fixes an issue where `foreign_amount` and `foreign_currency_id` were not being set for destination transactions during foreign currency transfer updates. This caused balance inconsistencies and errors such as `Sum of journal #%d is not zero` after restarting Firefly III. The changes ensure these fields are correctly populated to prevent such issues.


@JC5
