### PR TITLE
Add ability to set a rule that will trigger both when rules are created or updated

### DIFF
--- a/app/Api/V1/Requests/Models/Rule/StoreRequest.php
+++ b/app/Api/V1/Requests/Models/Rule/StoreRequest.php
@@ -119,7 +119,7 @@ class StoreRequest extends FormRequest
             'description'                => 'min:1|max:32768|nullable',
             'rule_group_id'              => 'belongsToUser:rule_groups|required_without:rule_group_title',
             'rule_group_title'           => 'nullable|min:1|max:255|required_without:rule_group_id|belongsToUser:rule_groups,title',
-            'trigger'                    => 'required|in:store-journal,update-journal,manual-activation',
+            'trigger'                    => 'required|in:store-journal,update-journal,manual-activation,store-or-update-journal',
             'triggers.*.type'            => 'required|in:'.implode(',', $validTriggers),
             'triggers.*.value'           => 'required_if:actions.*.type,'.$contextTriggers.'|min:1|ruleTriggerValue|max:1024',
             'triggers.*.stop_processing' => [new IsBoolean()],

--- a/app/Api/V1/Requests/Models/Rule/UpdateRequest.php
+++ b/app/Api/V1/Requests/Models/Rule/UpdateRequest.php
@@ -138,7 +138,7 @@ class UpdateRequest extends FormRequest
             'description'                => 'min:1|max:32768|nullable',
             'rule_group_id'              => 'belongsToUser:rule_groups',
             'rule_group_title'           => 'nullable|min:1|max:255|belongsToUser:rule_groups,title',
-            'trigger'                    => 'in:store-journal,update-journal.manual-activation',
+            'trigger'                    => 'in:store-journal,update-journal.manual-activation,store-or-update-journal',
             'triggers.*.type'            => 'required|in:'.implode(',', $validTriggers),
             'triggers.*.value'           => 'required_if:actions.*.type,'.$contextTriggers.'|min:1|ruleTriggerValue|max:1024',
             'triggers.*.stop_processing' => [new IsBoolean()],

--- a/app/Handlers/Events/StoredGroupEventHandler.php
+++ b/app/Handlers/Events/StoredGroupEventHandler.php
@@ -66,7 +66,7 @@ class StoredGroupEventHandler
 
         // add the groups to the rule engine.
         // it should run the rules in the group and cancel the group if necessary.
-        $groups              = $ruleGroupRepository->getRuleGroupsWithRules('store-journal');
+        $groups              = $ruleGroupRepository->getRuleGroupsWithRules(['store-journal', 'store-or-update-journal']);
 
         // create and fire rule engine.
         $newRuleEngine       = app(RuleEngineInterface::class);

--- a/app/Handlers/Events/UpdatedGroupEventHandler.php
+++ b/app/Handlers/Events/UpdatedGroupEventHandler.php
@@ -66,7 +66,7 @@ class UpdatedGroupEventHandler
         $ruleGroupRepository = app(RuleGroupRepositoryInterface::class);
         $ruleGroupRepository->setUser($updatedGroupEvent->transactionGroup->user);
 
-        $groups              = $ruleGroupRepository->getRuleGroupsWithRules('update-journal');
+        $groups              = $ruleGroupRepository->getRuleGroupsWithRules(['update-journal', 'store-or-update-journal']);
 
         // file rule engine.
         $newRuleEngine       = app(RuleEngineInterface::class);

--- a/app/Http/Requests/RuleFormRequest.php
+++ b/app/Http/Requests/RuleFormRequest.php
@@ -144,7 +144,7 @@ class RuleFormRequest extends FormRequest
             'description'      => 'min:1|max:32768|nullable',
             'stop_processing'  => 'boolean',
             'rule_group_id'    => 'required|belongsToUser:rule_groups',
-            'trigger'          => 'required|in:store-journal,update-journal,manual-activation',
+            'trigger'          => 'required|in:store-journal,update-journal,manual-activation,store-or-update-journal',
             'triggers.*.type'  => 'required|in:'.implode(',', $validTriggers),
             'triggers.*.value' => sprintf('required_if:triggers.*.type,%s|max:1024|min:1|ruleTriggerValue', $contextTriggers),
             'actions.*.type'   => 'required|in:'.implode(',', $validActions),

--- a/app/Repositories/Rule/RuleRepository.php
+++ b/app/Repositories/Rule/RuleRepository.php
@@ -175,7 +175,7 @@ class RuleRepository implements RuleRepositoryInterface
         foreach ($collection as $rule) {
             /** @var RuleTrigger $ruleTrigger */
             foreach ($rule->ruleTriggers as $ruleTrigger) {
-                if ('user_action' === $ruleTrigger->trigger_type && 'store-journal' === $ruleTrigger->trigger_value) {
+                if ('user_action' === $ruleTrigger->trigger_type && in_array($ruleTrigger->trigger_value, ['store-journal','store-or-update-journal'], true)) {
                     $filtered->push($rule);
                 }
             }
@@ -201,7 +201,7 @@ class RuleRepository implements RuleRepositoryInterface
         foreach ($collection as $rule) {
             /** @var RuleTrigger $ruleTrigger */
             foreach ($rule->ruleTriggers as $ruleTrigger) {
-                if ('user_action' === $ruleTrigger->trigger_type && 'update-journal' === $ruleTrigger->trigger_value) {
+                if ('user_action' === $ruleTrigger->trigger_type && in_array($ruleTrigger->trigger_value, ['update-journal','store-or-update-journal'], true)) {
                     $filtered->push($rule);
                 }
             }
@@ -493,6 +493,9 @@ class RuleRepository implements RuleRepositoryInterface
         }
         if (array_key_exists('trigger', $data) && 'store-journal' === $data['trigger']) {
             $this->setRuleTrigger('store-journal', $rule);
+        }
+        if (array_key_exists('trigger', $data) && 'store-or-update-journal' === $data['trigger']) {
+            $this->setRuleTrigger('store-or-update-journal', $rule);
         }
         if (array_key_exists('triggers', $data)) {
             // delete triggers:

--- a/app/Repositories/RuleGroup/RuleGroupRepositoryInterface.php
+++ b/app/Repositories/RuleGroup/RuleGroupRepositoryInterface.php
@@ -71,7 +71,7 @@ interface RuleGroupRepositoryInterface
 
     public function getHighestOrderRuleGroup(): int;
 
-    public function getRuleGroupsWithRules(?string $filter): Collection;
+    public function getRuleGroupsWithRules(?array $filter): Collection;
 
     public function getRules(RuleGroup $group): Collection;
 

--- a/app/Support/Twig/Rule.php
+++ b/app/Support/Twig/Rule.php
@@ -46,9 +46,10 @@ class Rule extends AbstractExtension
             'allJournalTriggers',
             static function () {
                 return [
-                    'store-journal'     => (string) trans('firefly.rule_trigger_store_journal'),
-                    'update-journal'    => (string) trans('firefly.rule_trigger_update_journal'),
-                    'manual-activation' => (string) trans('firefly.rule_trigger_manual'),
+                    'store-journal'           => (string) trans('firefly.rule_trigger_store_journal'),
+                    'update-journal'          => (string) trans('firefly.rule_trigger_update_journal'),
+                    'store-or-update-journal' => (string) trans('firefly.rule_trigger_store_or_update_journal'),
+                    'manual-activation'       => (string) trans('firefly.rule_trigger_manual'),
                 ];
             }
         );

--- a/resources/lang/en_US/firefly.php
+++ b/resources/lang/en_US/firefly.php
@@ -821,6 +821,7 @@ return [
     // actions and triggers
     'rule_trigger_store_journal'                           => 'When a transaction is created',
     'rule_trigger_update_journal'                          => 'When a transaction is updated',
+    'rule_trigger_store_or_update_journal'                 => 'When a transaction is created or updated',
     'rule_trigger_manual'                                  => 'Only when user-activated',
     'rule_trigger_user_action'                             => 'User action is ":trigger_value"',
 


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue #8948. 

It got annoying to have to decide whether my rules needed to trigger when updating or when creating as I do some sanitizing of data through webhooks - For those cases, I have to wait for the sanitizing update to happen. In other cases, the data is fine up front so no update happens.

Changes in this pull request:

- Add a third option to the Rules dropdown, `store-or-update-journal` (In English named "When a transaction is created or updated")
- Modified all code that looked for `store-journal` or `update-journal` to also look for `store-or-update-journal` when fetching rules
   - To do this, `getRuleGroupsWithRules` now take an optional array rather than an optional string
- Modified all logic that handles creation of rules to also handle this new case.

@JC5
