### PR TITLE
Feature nordic currencies

### DIFF
--- a/database/seeders/TransactionCurrencySeeder.php
+++ b/database/seeders/TransactionCurrencySeeder.php
@@ -42,6 +42,7 @@ class TransactionCurrencySeeder extends Seeder
         $currencies[] = ['code' => 'PLN', 'name' => 'Polish złoty', 'symbol' => 'zł', 'decimal_places' => 2];
         $currencies[] = ['code' => 'TRY', 'name' => 'Turkish lira', 'symbol' => '₺', 'decimal_places' => 2];
         $currencies[] = ['code' => 'DKK', 'name' => 'Dansk krone', 'symbol' => 'kr.', 'decimal_places' => 2];
+        $currencies[] = ['code' => 'ISK', 'name' => 'Íslensk króna', 'symbol' => 'kr.', 'decimal_places' => 2];
         $currencies[] = ['code' => 'NOK', 'name' => 'Norsk krone', 'symbol' => 'kr.', 'decimal_places' => 2];
         $currencies[] = ['code' => 'SEK', 'name' => 'Svensk krona', 'symbol' => 'kr.', 'decimal_places' => 2];
         $currencies[] = ['code' => 'RON', 'name' => 'Romanian leu', 'symbol' => 'lei', 'decimal_places' => 2];

--- a/database/seeders/TransactionCurrencySeeder.php
+++ b/database/seeders/TransactionCurrencySeeder.php
@@ -42,6 +42,7 @@ class TransactionCurrencySeeder extends Seeder
         $currencies[] = ['code' => 'PLN', 'name' => 'Polish złoty', 'symbol' => 'zł', 'decimal_places' => 2];
         $currencies[] = ['code' => 'TRY', 'name' => 'Turkish lira', 'symbol' => '₺', 'decimal_places' => 2];
         $currencies[] = ['code' => 'DKK', 'name' => 'Dansk krone', 'symbol' => 'kr.', 'decimal_places' => 2];
+        $currencies[] = ['code' => 'NOK', 'name' => 'Norsk krone', 'symbol' => 'kr.', 'decimal_places' => 2];
         $currencies[] = ['code' => 'SEK', 'name' => 'Svensk krona', 'symbol' => 'kr.', 'decimal_places' => 2];
         $currencies[] = ['code' => 'RON', 'name' => 'Romanian leu', 'symbol' => 'lei', 'decimal_places' => 2];
 

--- a/database/seeders/TransactionCurrencySeeder.php
+++ b/database/seeders/TransactionCurrencySeeder.php
@@ -42,6 +42,7 @@ class TransactionCurrencySeeder extends Seeder
         $currencies[] = ['code' => 'PLN', 'name' => 'Polish złoty', 'symbol' => 'zł', 'decimal_places' => 2];
         $currencies[] = ['code' => 'TRY', 'name' => 'Turkish lira', 'symbol' => '₺', 'decimal_places' => 2];
         $currencies[] = ['code' => 'DKK', 'name' => 'Dansk krone', 'symbol' => 'kr.', 'decimal_places' => 2];
+        $currencies[] = ['code' => 'SEK', 'name' => 'Svensk krona', 'symbol' => 'kr.', 'decimal_places' => 2];
         $currencies[] = ['code' => 'RON', 'name' => 'Romanian leu', 'symbol' => 'lei', 'decimal_places' => 2];
 
         // american currencies


### PR DESCRIPTION
Changes in this pull request:

- Adding SEK
- Adding NOK
- Adding ISK

Most of the nordic countries in Europe have some different flavours of 'Krona'. I only found the Danish krone in the repo so I added the Swedish, Norwegian and Icelandic to be more inclusive. This feels inline with the currency exchange you are currently implementing.

References:
 - https://sv.wikipedia.org/wiki/Svensk_krona
 - https://no.wikipedia.org/wiki/Norsk_krone
 - https://is.wikipedia.org/wiki/%C3%8Dslensk_kr%C3%B3na
@JC5
