### PR TITLE
fix: ignore the Procfile when building the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Procfile


### PR DESCRIPTION
This PR fixes issue #9833.

Changes in this pull request:

- This PR removes the Procfile from the built docker image. The Procfile is heroku-specific, causing issues on platforms which respect it when specifying processes to run for docker image or dockerfile based deploys.

@JC5
