### PR TITLE
fix transaction group user issue

### DIFF
--- a/.ci/php-cs-fixer/composer.lock
+++ b/.ci/php-cs-fixer/composer.lock
@@ -406,16 +406,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.69.0",
+            "version": "v3.69.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "630a59448c00729bc235d5e95cfedefeaca37523"
+                "reference": "13b0c0eede38c11cd674b080f2b485d0f14ffa9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/630a59448c00729bc235d5e95cfedefeaca37523",
-                "reference": "630a59448c00729bc235d5e95cfedefeaca37523",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/13b0c0eede38c11cd674b080f2b485d0f14ffa9f",
+                "reference": "13b0c0eede38c11cd674b080f2b485d0f14ffa9f",
                 "shasum": ""
             },
             "require": {
@@ -497,7 +497,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.69.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.69.1"
             },
             "funding": [
                 {
@@ -505,7 +505,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-14T16:19:23+00:00"
+            "time": "2025-02-18T23:57:43+00:00"
         },
         {
             "name": "psr/container",

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Procfile

--- a/THANKS.md
+++ b/THANKS.md
@@ -4,6 +4,7 @@ Over time, many people have contributed to Firefly III. Their efforts are not al
 Please find below all the people who contributed to the Firefly III code. Their names are mentioned in the year of their first contribution.
 
 ## 2025
+- Jose Diaz-Gonzalez
 - SoftBrix
 
 ## 2024

--- a/app/Api/V1/Controllers/Models/Transaction/StoreController.php
+++ b/app/Api/V1/Controllers/Models/Transaction/StoreController.php
@@ -90,6 +90,7 @@ class StoreController extends Controller
         $data['user']       = auth()->user();
         $data['user_group'] = $this->userGroup;
 
+
         Log::channel('audit')->info('Store new transaction over API.', $data);
 
         try {

--- a/app/Api/V2/Controllers/Model/Transaction/StoreController.php
+++ b/app/Api/V2/Controllers/Model/Transaction/StoreController.php
@@ -73,6 +73,7 @@ class StoreController extends Controller
         $userGroup          = $request->getUserGroup();
         $data['user_group'] = $userGroup;
 
+
         // overrule user group and see where we end up.
         // what happens when we refer to a budget that is not in this user group?
 

--- a/app/Console/Commands/Upgrade/UpgradesToGroups.php
+++ b/app/Console/Commands/Upgrade/UpgradesToGroups.php
@@ -238,7 +238,8 @@ class UpgradesToGroups extends Command
         return [
             'type'                => strtolower($journal->transactionType->type),
             'date'                => $journal->date,
-            'user'                => $journal->user_id,
+            'user'                => $journal->user,
+            'user_group'          => $journal->user->userGroup,
             'currency_id'         => $transaction->transaction_currency_id,
             'foreign_currency_id' => $transaction->foreign_currency_id,
             'amount'              => $transaction->amount,

--- a/app/Factory/TransactionGroupFactory.php
+++ b/app/Factory/TransactionGroupFactory.php
@@ -56,8 +56,8 @@ class TransactionGroupFactory
     public function create(array $data): TransactionGroup
     {
         app('log')->debug('Now in TransactionGroupFactory::create()');
-        $this->journalFactory->setUser($data['user']);
-        $this->journalFactory->setUserGroup($data['user_group']);
+        $this->journalFactory->setUser($this->user);
+        $this->journalFactory->setUserGroup($this->userGroup);
         $this->journalFactory->setErrorOnHash($data['error_if_duplicate_hash'] ?? false);
 
         try {

--- a/app/Http/Controllers/Account/ReconcileController.php
+++ b/app/Http/Controllers/Account/ReconcileController.php
@@ -87,10 +87,10 @@ class ReconcileController extends Controller
 
             return redirect(route('accounts.index', [config(sprintf('firefly.shortNamesByFullName.%s', $account->accountType->type))]));
         }
-        $currency = $this->accountRepos->getAccountCurrency($account) ?? $this->defaultCurrency;
+        $currency        = $this->accountRepos->getAccountCurrency($account) ?? $this->defaultCurrency;
 
         // no start or end:
-        $range = app('navigation')->getViewRange(false);
+        $range           = app('navigation')->getViewRange(false);
 
         // get start and end
 
@@ -99,7 +99,7 @@ class ReconcileController extends Controller
             $start = clone session('start', app('navigation')->startOfPeriod(new Carbon(), $range));
 
             /** @var Carbon $end */
-            $end = clone session('end', app('navigation')->endOfPeriod(new Carbon(), $range));
+            $end   = clone session('end', app('navigation')->endOfPeriod(new Carbon(), $range));
         }
         if (null === $end) {
             /** @var Carbon $end */
@@ -113,15 +113,15 @@ class ReconcileController extends Controller
         $start->startOfDay();
         $end->endOfDay();
 
-        $startDate = clone $start;
+        $startDate       = clone $start;
         $startDate->subDay()->endOfDay(); // this is correct, subday endofday ends at 23:59:59
         // both are validated and are correct.
         Log::debug(sprintf('reconcile: Call finalAccountBalance with date/time "%s"', $startDate->toIso8601String()));
         Log::debug(sprintf('reconcile2: Call finalAccountBalance with date/time "%s"', $end->toIso8601String()));
-        $startBalance = Steam::bcround(Steam::finalAccountBalance($account, $startDate)['balance'], $currency->decimal_places);
-        $endBalance   = Steam::bcround(Steam::finalAccountBalance($account, $end)['balance'], $currency->decimal_places);
-        $subTitleIcon = config(sprintf('firefly.subIconsByIdentifier.%s', $account->accountType->type));
-        $subTitle     = (string) trans('firefly.reconcile_account', ['account' => $account->name]);
+        $startBalance    = Steam::bcround(Steam::finalAccountBalance($account, $startDate)['balance'], $currency->decimal_places);
+        $endBalance      = Steam::bcround(Steam::finalAccountBalance($account, $end)['balance'], $currency->decimal_places);
+        $subTitleIcon    = config(sprintf('firefly.subIconsByIdentifier.%s', $account->accountType->type));
+        $subTitle        = (string) trans('firefly.reconcile_account', ['account' => $account->name]);
 
         // various links
         $transactionsUrl = route('accounts.reconcile.transactions', [$account->id, '%start%', '%end%']);
@@ -162,7 +162,7 @@ class ReconcileController extends Controller
         }
 
         app('log')->debug('In ReconcileController::submit()');
-        $data = $request->getAll();
+        $data   = $request->getAll();
 
         /** @var string $journalId */
         foreach ($data['journals'] as $journalId) {
@@ -217,14 +217,14 @@ class ReconcileController extends Controller
         }
 
         // title:
-        $description = trans(
+        $description    = trans(
             'firefly.reconciliation_transaction_title',
             [
                 'from' => $start->isoFormat($this->monthAndDayFormat),
                 'to'   => $end->isoFormat($this->monthAndDayFormat),
             ]
         );
-        $submission  = [
+        $submission     = [
             'user'         => auth()->user()->id,
             'group_title'  => null,
             'transactions' => [
@@ -247,10 +247,10 @@ class ReconcileController extends Controller
         ];
 
         /** @var TransactionGroupFactory $factory */
-        $factory = app(TransactionGroupFactory::class);
+        $factory        = app(TransactionGroupFactory::class);
 
         /** @var User $user */
-        $user = auth()->user();
+        $user           = auth()->user();
         $factory->setUser($user);
 
         try {

--- a/app/Http/Controllers/Transaction/ShowController.php
+++ b/app/Http/Controllers/Transaction/ShowController.php
@@ -103,7 +103,7 @@ class ShowController extends Controller
 
         foreach (array_keys($groupArray['transactions']) as $index) {
             $groupArray['transactions'][$index]['tags'] = $this->repository->getTagObjects(
-                $groupArray['transactions'][$index]['transaction_journal_id']
+                (int) $groupArray['transactions'][$index]['transaction_journal_id']
             );
         }
 

--- a/app/Repositories/Account/AccountRepository.php
+++ b/app/Repositories/Account/AccountRepository.php
@@ -498,6 +498,8 @@ class AccountRepository implements AccountRepositoryInterface
             }
             $query->orderBy('accounts.active', 'DESC');
             $query->orderBy('accounts.name', 'ASC');
+            $query->orderBy('accounts.account_type_id', 'ASC');
+            $query->orderBy('accounts.id', 'ASC');
         }
 
         return $query->get(['accounts.*']);

--- a/app/Repositories/PiggyBank/ModifiesPiggyBanks.php
+++ b/app/Repositories/PiggyBank/ModifiesPiggyBanks.php
@@ -233,8 +233,8 @@ trait ModifiesPiggyBanks
             $difference = bcsub($piggyBank->target_amount, $currentAmount);
 
             // an amount will be removed, create "negative" event:
-            Log::debug(sprintf('ChangedAmount: is triggered with difference "%s"', $difference));
-            event(new ChangedAmount($piggyBank, $difference, null, null));
+//            Log::debug(sprintf('ChangedAmount: is triggered with difference "%s"', $difference));
+//            event(new ChangedAmount($piggyBank, $difference, null, null));
 
             // question is, from which account(s) to remove the difference?
             // solution: just start from the top until there is no more money left to remove.

--- a/app/Repositories/PiggyBank/ModifiesPiggyBanks.php
+++ b/app/Repositories/PiggyBank/ModifiesPiggyBanks.php
@@ -233,8 +233,8 @@ trait ModifiesPiggyBanks
             $difference = bcsub($piggyBank->target_amount, $currentAmount);
 
             // an amount will be removed, create "negative" event:
-//            Log::debug(sprintf('ChangedAmount: is triggered with difference "%s"', $difference));
-//            event(new ChangedAmount($piggyBank, $difference, null, null));
+            //            Log::debug(sprintf('ChangedAmount: is triggered with difference "%s"', $difference));
+            //            event(new ChangedAmount($piggyBank, $difference, null, null));
 
             // question is, from which account(s) to remove the difference?
             // solution: just start from the top until there is no more money left to remove.

--- a/app/Repositories/TransactionGroup/TransactionGroupRepository.php
+++ b/app/Repositories/TransactionGroup/TransactionGroupRepository.php
@@ -400,8 +400,8 @@ class TransactionGroupRepository implements TransactionGroupRepositoryInterface
     {
         /** @var TransactionGroupFactory $factory */
         $factory = app(TransactionGroupFactory::class);
-        $factory->setUser($data['user']);
-        $factory->setUserGroup($data['user_group']);
+        $factory->setUser($this->user);
+        $factory->setUserGroup($this->userGroup);
 
         try {
             return $factory->create($data);

--- a/app/Repositories/UserGroups/Account/AccountRepository.php
+++ b/app/Repositories/UserGroups/Account/AccountRepository.php
@@ -361,6 +361,8 @@ class AccountRepository implements AccountRepositoryInterface
             }
             $query->orderBy('accounts.order', 'ASC');
             $query->orderBy('accounts.name', 'ASC');
+            $query->orderBy('accounts.account_type_id', 'ASC');
+            $query->orderBy('accounts.id', 'ASC');
         }
 
         return $query->get(['accounts.*']);

--- a/app/Support/JsonApi/Enrichments/AccountEnrichment.php
+++ b/app/Support/JsonApi/Enrichments/AccountEnrichment.php
@@ -234,7 +234,7 @@ class AccountEnrichment implements EnrichmentInterface
 
     private function collectMetaData(): void
     {
-        $set        = AccountMeta::whereIn('name', ['is_multi_currency', 'include_net_worth','currency_id', 'account_role', 'account_number', 'liability_direction', 'interest', 'interest_period', 'current_debt'])
+        $set        = AccountMeta::whereIn('name', ['is_multi_currency', 'include_net_worth', 'currency_id', 'account_role', 'account_number', 'liability_direction', 'interest', 'interest_period', 'current_debt'])
             ->whereIn('account_id', $this->accountIds)
             ->get(['account_meta.id', 'account_meta.account_id', 'account_meta.name', 'account_meta.data'])->toArray()
         ;

--- a/app/Support/JsonApi/Enrichments/AccountEnrichment.php
+++ b/app/Support/JsonApi/Enrichments/AccountEnrichment.php
@@ -234,7 +234,7 @@ class AccountEnrichment implements EnrichmentInterface
 
     private function collectMetaData(): void
     {
-        $set        = AccountMeta::whereIn('name', ['is_multi_currency', 'currency_id', 'account_role', 'account_number', 'liability_direction', 'interest', 'interest_period', 'current_debt'])
+        $set        = AccountMeta::whereIn('name', ['is_multi_currency', 'include_net_worth','currency_id', 'account_role', 'account_number', 'liability_direction', 'interest', 'interest_period', 'current_debt'])
             ->whereIn('account_id', $this->accountIds)
             ->get(['account_meta.id', 'account_meta.account_id', 'account_meta.name', 'account_meta.data'])->toArray()
         ;

--- a/app/Support/JsonApi/Enrichments/AccountEnrichment.php
+++ b/app/Support/JsonApi/Enrichments/AccountEnrichment.php
@@ -250,8 +250,9 @@ class AccountEnrichment implements EnrichmentInterface
         foreach ($currencies as $currency) {
             $this->currencies[(int) $currency->id] = $currency;
         }
+        $this->currencies[0] = $this->native;
         foreach ($this->currencies as $id => $currency) {
-            if (true === $currency && 0 !== (int) $id) {
+            if (true === $currency) {
                 throw new FireflyException(sprintf('Currency #%d not found.', $id));
             }
         }

--- a/app/Support/JsonApi/Enrichments/AccountEnrichment.php
+++ b/app/Support/JsonApi/Enrichments/AccountEnrichment.php
@@ -117,30 +117,6 @@ class AccountEnrichment implements EnrichmentInterface
         $this->collectNotes();
         $this->collectLocations();
         $this->collectOpeningBalances();
-        //        $this->default      = app('amount')->getNativeCurrency();
-        //        $this->currencies   = [];
-        //        $this->balances     = [];
-        //        $this->objectGroups = [];
-        //        $this->grouped      = [];
-        //
-        //        // do everything here:
-        //        $this->getLastActivity();
-        //        $this->collectAccountTypes();
-        //        $this->collectMetaData();
-        //        $this->getMetaBalances();
-        //        $this->getObjectGroups();
-
-        //        $this->collection->transform(function (Account $account) {
-        //            $account->user_array = ['id' => 1, 'bla bla' => 'bla'];
-        //            $account->balances   = collect([
-        //                ['balance_id' => 1, 'balance' => 5],
-        //                ['balance_id' => 2, 'balance' => 5],
-        //                ['balance_id' => 3, 'balance' => 5],
-        //            ]);
-        //
-        //            return $account;
-        //        });
-
         $this->appendCollectedData();
 
         return $this->collection;
@@ -275,7 +251,7 @@ class AccountEnrichment implements EnrichmentInterface
             $this->currencies[(int) $currency->id] = $currency;
         }
         foreach ($this->currencies as $id => $currency) {
-            if (true === $currency) {
+            if (true === $currency && 0 !== (int) $id) {
                 throw new FireflyException(sprintf('Currency #%d not found.', $id));
             }
         }

--- a/app/Support/JsonApi/Enrichments/AccountEnrichment.php
+++ b/app/Support/JsonApi/Enrichments/AccountEnrichment.php
@@ -234,7 +234,7 @@ class AccountEnrichment implements EnrichmentInterface
 
     private function collectMetaData(): void
     {
-        $set        = AccountMeta::whereIn('name', ['is_multi_currency', 'include_net_worth', 'currency_id', 'account_role', 'account_number', 'liability_direction', 'interest', 'interest_period', 'current_debt'])
+        $set                 = AccountMeta::whereIn('name', ['is_multi_currency', 'include_net_worth', 'currency_id', 'account_role', 'account_number', 'liability_direction', 'interest', 'interest_period', 'current_debt'])
             ->whereIn('account_id', $this->accountIds)
             ->get(['account_meta.id', 'account_meta.account_id', 'account_meta.name', 'account_meta.data'])->toArray()
         ;
@@ -246,7 +246,7 @@ class AccountEnrichment implements EnrichmentInterface
                 $this->currencies[(int) $entry['data']] = true;
             }
         }
-        $currencies = TransactionCurrency::whereIn('id', array_keys($this->currencies))->get();
+        $currencies          = TransactionCurrency::whereIn('id', array_keys($this->currencies))->get();
         foreach ($currencies as $currency) {
             $this->currencies[(int) $currency->id] = $currency;
         }

--- a/app/Support/Preferences.php
+++ b/app/Support/Preferences.php
@@ -47,15 +47,16 @@ class Preferences
         }
 
         return Preference::where('user_id', $user->id)
-                         ->where('name', '!=', 'currencyPreference')
-                         ->where(function (Builder $q) use ($user): void {
-                             $q->whereNull('user_group_id');
-                             $q->orWhere('user_group_id', $user->user_group_id);
-                         })
-                         ->get();
+            ->where('name', '!=', 'currencyPreference')
+            ->where(function (Builder $q) use ($user): void {
+                $q->whereNull('user_group_id');
+                $q->orWhere('user_group_id', $user->user_group_id);
+            })
+            ->get()
+        ;
     }
 
-    public function get(string $name, null | array | bool | int | string $default = null): ?Preference
+    public function get(string $name, null|array|bool|int|string $default = null): ?Preference
     {
         /** @var null|User $user */
         $user = auth()->user();
@@ -69,7 +70,7 @@ class Preferences
         return $this->getForUser($user, $name, $default);
     }
 
-    public function getForUser(User $user, string $name, null | array | bool | int | string $default = null): ?Preference
+    public function getForUser(User $user, string $name, null|array|bool|int|string $default = null): ?Preference
     {
         Log::debug(sprintf('getForUser(#%d, "%s")', $user->id, $name));
         // don't care about user group ID, except for some specific preferences.
@@ -80,7 +81,7 @@ class Preferences
             $query->where('user_group_id', $userGroupId);
         }
 
-        $preference = $query->first(['id', 'user_id', 'user_group_id', 'name', 'data', 'updated_at', 'created_at']);
+        $preference  = $query->first(['id', 'user_id', 'user_group_id', 'name', 'data', 'updated_at', 'created_at']);
 
         if (null !== $preference && null === $preference->data) {
             $preference->delete();
@@ -90,11 +91,13 @@ class Preferences
 
         if (null !== $preference) {
             Log::debug(sprintf('Found preference #%d for user #%d: %s', $preference->id, $user->id, $name));
+
             return $preference;
         }
         // no preference found and default is null:
         if (null === $default) {
             Log::debug('Return NULL, create no preference.');
+
             // return NULL
             return null;
         }
@@ -131,21 +134,21 @@ class Preferences
         Cache::put($key, '', 5);
     }
 
-    public function setForUser(User $user, string $name, null | array | bool | int | string $value): Preference
+    public function setForUser(User $user, string $name, null|array|bool|int|string $value): Preference
     {
-        $fullName = sprintf('preference%s%s', $user->id, $name);
-        $userGroupId  = $this->getUserGroupId($user, $name);
-        $userGroupId  = 0 === (int) $userGroupId ? null : (int) $userGroupId;
+        $fullName         = sprintf('preference%s%s', $user->id, $name);
+        $userGroupId      = $this->getUserGroupId($user, $name);
+        $userGroupId      = 0 === (int) $userGroupId ? null : (int) $userGroupId;
 
         Cache::forget($fullName);
 
-        $query       = Preference::where('user_id', $user->id)->where('name', $name);
+        $query            = Preference::where('user_id', $user->id)->where('name', $name);
         if (null !== $userGroupId) {
             Log::debug('Include user group ID in query');
             $query->where('user_group_id', $userGroupId);
         }
 
-        $preference = $query->first(['id', 'user_id', 'user_group_id', 'name', 'data', 'updated_at', 'created_at']);
+        $preference       = $query->first(['id', 'user_id', 'user_group_id', 'name', 'data', 'updated_at', 'created_at']);
 
         if (null !== $preference && null === $value) {
             $preference->delete();
@@ -188,12 +191,13 @@ class Preferences
     {
         $result      = [];
         $preferences = Preference::where('user_id', $user->id)
-                                 ->where(function (Builder $q) use ($user): void {
-                                     $q->whereNull('user_group_id');
-                                     $q->orWhere('user_group_id', $user->user_group_id);
-                                 })
-                                 ->whereIn('name', $list)
-                                 ->get(['id', 'name', 'data']);
+            ->where(function (Builder $q) use ($user): void {
+                $q->whereNull('user_group_id');
+                $q->orWhere('user_group_id', $user->user_group_id);
+            })
+            ->whereIn('name', $list)
+            ->get(['id', 'name', 'data'])
+        ;
 
         /** @var Preference $preference */
         foreach ($preferences as $preference) {
@@ -235,7 +239,7 @@ class Preferences
         return $result;
     }
 
-    public function getEncryptedForUser(User $user, string $name, null | array | bool | int | string $default = null): ?Preference
+    public function getEncryptedForUser(User $user, string $name, null|array|bool|int|string $default = null): ?Preference
     {
         $result = $this->getForUser($user, $name, $default);
         if ('' === $result->data) {
@@ -260,7 +264,7 @@ class Preferences
         return $result;
     }
 
-    public function getFresh(string $name, null | array | bool | int | string $default = null): ?Preference
+    public function getFresh(string $name, null|array|bool|int|string $default = null): ?Preference
     {
         /** @var null|User $user */
         $user = auth()->user();
@@ -298,7 +302,7 @@ class Preferences
         Session::forget('first');
     }
 
-    public function set(string $name, null | array | bool | int | string $value): Preference
+    public function set(string $name, null|array|bool|int|string $value): Preference
     {
         /** @var null|User $user */
         $user = auth()->user();

--- a/app/Transformers/AccountTransformer.php
+++ b/app/Transformers/AccountTransformer.php
@@ -92,7 +92,7 @@ class AccountTransformer extends AbstractTransformer
         $decimalPlaces                                                = (int) $account->meta['currency']?->decimal_places;
         $decimalPlaces                                                = 0 === $decimalPlaces ? 2 : $decimalPlaces;
         $openingBalance                                               = Steam::bcround($openingBalance, $decimalPlaces);
-        $includeNetWorth                                              = '0' !== ($account->meta['include_net_worth'] ?? null);
+        $includeNetWorth                                              = 1 === (int) ($account->meta['include_net_worth'] ?? 0);
         $longitude                                                    = $account->meta['location']['longitude'] ?? null;
         $latitude                                                     = $account->meta['location']['latitude'] ?? null;
         $zoomLevel                                                    = $account->meta['location']['zoom_level'] ?? null;

--- a/app/Transformers/TransactionGroupTransformer.php
+++ b/app/Transformers/TransactionGroupTransformer.php
@@ -131,7 +131,7 @@ class TransactionGroupTransformer extends AbstractTransformer
 
         return [
             'user'                            => (string) $transaction['user_id'],
-            'transaction_journal_id'          => $transaction['transaction_journal_id'],
+            'transaction_journal_id'          => (string) $transaction['transaction_journal_id'],
             'type'                            => strtolower($type),
             'date'                            => $transaction['date']->toAtomString(),
             'order'                           => $transaction['order'],
@@ -320,17 +320,17 @@ class TransactionGroupTransformer extends AbstractTransformer
 
         return [
             'user'                            => $journal->user_id,
-            'transaction_journal_id'          => $journal->id,
+            'transaction_journal_id'          => (string) $journal->id,
             'type'                            => strtolower($type),
             'date'                            => $journal->date->toAtomString(),
             'order'                           => $journal->order,
 
-            'currency_id'                     => $currency->id,
+            'currency_id'                     => (string) $currency->id,
             'currency_code'                   => $currency->code,
             'currency_symbol'                 => $currency->symbol,
             'currency_decimal_places'         => $currency->decimal_places,
 
-            'foreign_currency_id'             => $foreignCurrency['id'],
+            'foreign_currency_id'             => (string) $foreignCurrency['id'],
             'foreign_currency_code'           => $foreignCurrency['code'],
             'foreign_currency_symbol'         => $foreignCurrency['symbol'],
             'foreign_currency_decimal_places' => $foreignCurrency['decimal_places'],
@@ -340,23 +340,23 @@ class TransactionGroupTransformer extends AbstractTransformer
 
             'description'                     => $journal->description,
 
-            'source_id'                       => $source->account_id,
+            'source_id'                       => (string) $source->account_id,
             'source_name'                     => $source->account->name,
             'source_iban'                     => $source->account->iban,
             'source_type'                     => $source->account->accountType->type,
 
-            'destination_id'                  => $destination->account_id,
+            'destination_id'                  => (string) $destination->account_id,
             'destination_name'                => $destination->account->name,
             'destination_iban'                => $destination->account->iban,
             'destination_type'                => $destination->account->accountType->type,
 
-            'budget_id'                       => $budget['id'],
+            'budget_id'                       => (string) $budget['id'],
             'budget_name'                     => $budget['name'],
 
-            'category_id'                     => $category['id'],
+            'category_id'                     => (string) $category['id'],
             'category_name'                   => $category['name'],
 
-            'bill_id'                         => $bill['id'],
+            'bill_id'                         => (string) $bill['id'],
             'bill_name'                       => $bill['name'],
 
             'reconciled'                      => $source->reconciled,

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 6.2.8 - 2025-02-22
+
+### Fixed
+
+- #9861
+- #9862
+- #9863
+- #9868
+- #9871
+- #9882
+
 ## 6.2.7 - 2025-02-19
 
 ### Changed

--- a/changelog.md
+++ b/changelog.md
@@ -7,12 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- #9861
-- #9862
-- #9863
-- #9868
-- #9871
-- #9882
+- [Issue 9861](https://github.com/firefly-iii/firefly-iii/issues/9861) (lower piggy amount when full creates double audit log entry) reported by @4e868df3
+- [Issue 9862](https://github.com/firefly-iii/firefly-iii/issues/9862) (Can't retrieve all accounts with the same name via API) reported by @Toshik1978
+- [Issue 9863](https://github.com/firefly-iii/firefly-iii/issues/9863) (User preferences reset after restart) reported by @mico28
+- [Issue 9868](https://github.com/firefly-iii/firefly-iii/issues/9868) (API: `TransactionSplit` -> `transaction_journal_id` returns int, not String) reported by @dreautall
+- [Issue 9871](https://github.com/firefly-iii/firefly-iii/issues/9871) (include net worth is ignored in the API - from PICO developer) reported by @fate8383
+- [Issue 9882](https://github.com/firefly-iii/firefly-iii/issues/9882) (Reconciliation bug on Docker instance) reported by @benjaminteyssier
 
 ## 6.2.7 - 2025-02-19
 

--- a/composer.lock
+++ b/composer.lock
@@ -3703,16 +3703,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.8.5",
+            "version": "3.8.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "b1a53a27898639579a67de42e8ced5d5386aa9a4"
+                "reference": "ff2f20cf83bd4d503720632ce8a426dc747bf7fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/b1a53a27898639579a67de42e8ced5d5386aa9a4",
-                "reference": "b1a53a27898639579a67de42e8ced5d5386aa9a4",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/ff2f20cf83bd4d503720632ce8a426dc747bf7fd",
+                "reference": "ff2f20cf83bd4d503720632ce8a426dc747bf7fd",
                 "shasum": ""
             },
             "require": {
@@ -3805,7 +3805,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-11T16:28:45+00:00"
+            "time": "2025-02-20T17:33:38+00:00"
         },
         {
             "name": "nette/schema",
@@ -6274,23 +6274,23 @@
         },
         {
             "name": "spatie/laravel-ignition",
-            "version": "2.9.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-ignition.git",
-                "reference": "62042df15314b829d0f26e02108f559018e2aad0"
+                "reference": "1baee07216d6748ebd3a65ba97381b051838707a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-ignition/zipball/62042df15314b829d0f26e02108f559018e2aad0",
-                "reference": "62042df15314b829d0f26e02108f559018e2aad0",
+                "url": "https://api.github.com/repos/spatie/laravel-ignition/zipball/1baee07216d6748ebd3a65ba97381b051838707a",
+                "reference": "1baee07216d6748ebd3a65ba97381b051838707a",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "illuminate/support": "^10.0|^11.0",
+                "illuminate/support": "^10.0|^11.0|^12.0",
                 "php": "^8.1",
                 "spatie/ignition": "^1.15",
                 "symfony/console": "^6.2.3|^7.0",
@@ -6299,12 +6299,12 @@
             "require-dev": {
                 "livewire/livewire": "^2.11|^3.3.5",
                 "mockery/mockery": "^1.5.1",
-                "openai-php/client": "^0.8.1",
-                "orchestra/testbench": "8.22.3|^9.0",
-                "pestphp/pest": "^2.34",
+                "openai-php/client": "^0.8.1|^0.10",
+                "orchestra/testbench": "8.22.3|^9.0|^10.0",
+                "pestphp/pest": "^2.34|^3.7",
                 "phpstan/extension-installer": "^1.3.1",
-                "phpstan/phpstan-deprecation-rules": "^1.1.1",
-                "phpstan/phpstan-phpunit": "^1.3.16",
+                "phpstan/phpstan-deprecation-rules": "^1.1.1|^2.0",
+                "phpstan/phpstan-phpunit": "^1.3.16|^2.0",
                 "vlucas/phpdotenv": "^5.5"
             },
             "suggest": {
@@ -6361,7 +6361,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-02T08:43:31+00:00"
+            "time": "2025-02-20T13:13:55+00:00"
         },
         {
             "name": "spatie/laravel-package-tools",
@@ -10587,40 +10587,40 @@
         },
         {
             "name": "larastan/larastan",
-            "version": "v3.0.4",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/larastan/larastan.git",
-                "reference": "b394eba5805727423071fac9b53ea50dd7e920f4"
+                "reference": "dbb2dc20e5c8e1ed3ff289054e1955f269187312"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/larastan/larastan/zipball/b394eba5805727423071fac9b53ea50dd7e920f4",
-                "reference": "b394eba5805727423071fac9b53ea50dd7e920f4",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/dbb2dc20e5c8e1ed3ff289054e1955f269187312",
+                "reference": "dbb2dc20e5c8e1ed3ff289054e1955f269187312",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "illuminate/console": "^11.15.0",
-                "illuminate/container": "^11.15.0",
-                "illuminate/contracts": "^11.15.0",
-                "illuminate/database": "^11.15.0",
-                "illuminate/http": "^11.15.0",
-                "illuminate/pipeline": "^11.15.0",
-                "illuminate/support": "^11.15.0",
+                "illuminate/console": "^11.15.0 || ^12.0",
+                "illuminate/container": "^11.15.0 || ^12.0",
+                "illuminate/contracts": "^11.15.0 || ^12.0",
+                "illuminate/database": "^11.15.0 || ^12.0",
+                "illuminate/http": "^11.15.0 || ^12.0",
+                "illuminate/pipeline": "^11.15.0 || ^12.0",
+                "illuminate/support": "^11.15.0 || ^12.0",
                 "php": "^8.2",
                 "phpmyadmin/sql-parser": "^5.9.0",
                 "phpstan/phpstan": "^2.1.3"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^12.0",
-                "laravel/framework": "^11.15.0",
+                "laravel/framework": "^11.15.0 || ^12.0",
                 "mockery/mockery": "^1.6",
                 "nikic/php-parser": "^5.3",
-                "orchestra/canvas": "^v9.1.3",
-                "orchestra/testbench-core": "^9.5.2",
+                "orchestra/canvas": "^v9.1.3 || ^10.0",
+                "orchestra/testbench-core": "^9.5.2 || ^10.0",
                 "phpstan/phpstan-deprecation-rules": "^2.0.0",
-                "phpunit/phpunit": "^10.5.16"
+                "phpunit/phpunit": "^10.5.35 || ^11.3.6"
             },
             "suggest": {
                 "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
@@ -10633,7 +10633,7 @@
                     ]
                 },
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -10668,7 +10668,7 @@
             ],
             "support": {
                 "issues": "https://github.com/larastan/larastan/issues",
-                "source": "https://github.com/larastan/larastan/tree/v3.0.4"
+                "source": "https://github.com/larastan/larastan/tree/v3.1.0"
             },
             "funding": [
                 {
@@ -10676,7 +10676,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-06T21:03:36+00:00"
+            "time": "2025-02-20T15:25:15+00:00"
         },
         {
             "name": "laravel-json-api/testing",
@@ -11743,16 +11743,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.8",
+            "version": "11.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c9bd61aab12f0fc5e82ecfe621ff518a1d1f1049"
+                "reference": "c91c830e7108a81e5845aeb6ba8fe3c1a4351c0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c9bd61aab12f0fc5e82ecfe621ff518a1d1f1049",
-                "reference": "c9bd61aab12f0fc5e82ecfe621ff518a1d1f1049",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c91c830e7108a81e5845aeb6ba8fe3c1a4351c0b",
+                "reference": "c91c830e7108a81e5845aeb6ba8fe3c1a4351c0b",
                 "shasum": ""
             },
             "require": {
@@ -11762,7 +11762,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.1",
+                "myclabs/deep-copy": "^1.13.0",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.2",
@@ -11824,7 +11824,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.8"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.9"
             },
             "funding": [
                 {
@@ -11840,7 +11840,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-18T06:26:59+00:00"
+            "time": "2025-02-21T06:08:50+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -1874,16 +1874,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v11.43.0",
+            "version": "v11.43.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "70760d976486310b11d8e487e873077db069e77a"
+                "reference": "99d1573698abc42222f04d25fcd5b213d0eedf21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/70760d976486310b11d8e487e873077db069e77a",
-                "reference": "70760d976486310b11d8e487e873077db069e77a",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/99d1573698abc42222f04d25fcd5b213d0eedf21",
+                "reference": "99d1573698abc42222f04d25fcd5b213d0eedf21",
                 "shasum": ""
             },
             "require": {
@@ -2085,7 +2085,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-02-18T15:37:56+00:00"
+            "time": "2025-02-19T21:53:48+00:00"
         },
         {
             "name": "laravel/passport",
@@ -11267,16 +11267,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.5",
+            "version": "2.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "451b17f9665481ee502adc39be987cb71067ece2"
+                "reference": "6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/451b17f9665481ee502adc39be987cb71067ece2",
-                "reference": "451b17f9665481ee502adc39be987cb71067ece2",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c",
+                "reference": "6eaec7c6c9e90dcfe46ad1e1ffa5171e2dab641c",
                 "shasum": ""
             },
             "require": {
@@ -11321,7 +11321,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-13T12:49:56+00:00"
+            "time": "2025-02-19T15:46:42+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",

--- a/config/firefly.php
+++ b/config/firefly.php
@@ -81,7 +81,7 @@ return [
         'running_balance_column' => env('USE_RUNNING_BALANCE', false),
         // see cer.php for exchange rates feature flag.
     ],
-    'version'                      => 'develop/2025-02-20',
+    'version'                      => 'develop/2025-02-21',
     'api_version'                  => '2.1.0', // field is no longer used.
     'db_version'                   => 25,
 

--- a/config/firefly.php
+++ b/config/firefly.php
@@ -81,7 +81,7 @@ return [
         'running_balance_column' => env('USE_RUNNING_BALANCE', false),
         // see cer.php for exchange rates feature flag.
     ],
-    'version'                      => '6.2.7',
+    'version'                      => 'develop/2025-02-19',
     'api_version'                  => '2.1.0', // field is no longer used.
     'db_version'                   => 25,
 

--- a/config/firefly.php
+++ b/config/firefly.php
@@ -81,7 +81,7 @@ return [
         'running_balance_column' => env('USE_RUNNING_BALANCE', false),
         // see cer.php for exchange rates feature flag.
     ],
-    'version'                      => 'develop/2025-02-19',
+    'version'                      => 'develop/2025-02-20',
     'api_version'                  => '2.1.0', // field is no longer used.
     'db_version'                   => 25,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4510,9 +4510,9 @@
             }
         },
         "node_modules/chart.js": {
-            "version": "4.4.7",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.7.tgz",
-            "integrity": "sha512-pwkcKfdzTMAU/+jNosKhNL2bHtJc/sSmYgVbuGTEDhzkrhmyihmP7vUc/5ZK9WopidMDHNe3Wm7jOd/WhuHWuw==",
+            "version": "4.4.8",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
+            "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
             "license": "MIT",
             "dependencies": {
                 "@kurkle/color": "^0.3.0"
@@ -8901,9 +8901,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.2",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
-            "integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
+            "version": "8.5.3",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+            "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
             "dev": true,
             "funding": [
                 {
@@ -11344,14 +11344,14 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.0.tgz",
-            "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.1.tgz",
+            "integrity": "sha512-4GgM54XrwRfrOp297aIYspIti66k56v16ZnqHvrIM7mG+HjDlAwS7p+Srr7J6fGvEdOJ5JcQ/D9T7HhtdXDTzA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.24.2",
-                "postcss": "^8.5.1",
+                "postcss": "^8.5.2",
                 "rollup": "^4.30.1"
             },
             "bin": {

--- a/resources/assets/v1/src/locales/it.json
+++ b/resources/assets/v1/src/locales/it.json
@@ -172,8 +172,8 @@
     },
     "list": {
         "title": "Titolo",
-        "active": "Attivo",
-        "native_currency": "Native currency",
+        "active": "\u00c8 attivo?",
+        "native_currency": "Valuta nativa",
         "trigger": "Trigger",
         "response": "Risposta",
         "delivery": "Consegna",


### PR DESCRIPTION
### **Fixes**  
This PR fixes issue **#9887**  

### **Changes in this pull request:**  
- Replaced `$data['user']` and `$data['user_group']` with `$this->user` and `$this->userGroup` in **TransactionGroupFactory::create()**  
- Replaced `$data['user']` and `$data['user_group']` with `$this->user` and `$this->userGroup` in **TransactionGroupRepository::store()**  

### **Why this fix is needed:**  
The previous implementation used `$data['user']` and `$data['user_group']`, which led to incorrect handling of user context. This fix ensures the factory and repository classes use the instance variables (`$this->user`, `$this->userGroup`) instead, aligning with the expected behavior.  


---

**@JC5**, please review when you have a chance! 🚀