### PR TITLE
Fix #9887

### DIFF
--- a/app/Factory/TransactionGroupFactory.php
+++ b/app/Factory/TransactionGroupFactory.php
@@ -56,8 +56,8 @@ class TransactionGroupFactory
     public function create(array $data): TransactionGroup
     {
         app('log')->debug('Now in TransactionGroupFactory::create()');
-        $this->journalFactory->setUser($data['user']);
-        $this->journalFactory->setUserGroup($data['user_group']);
+        $this->journalFactory->setUser($this->user);
+        $this->journalFactory->setUserGroup($this->userGroup);
         $this->journalFactory->setErrorOnHash($data['error_if_duplicate_hash'] ?? false);
 
         try {

--- a/app/Repositories/TransactionGroup/TransactionGroupRepository.php
+++ b/app/Repositories/TransactionGroup/TransactionGroupRepository.php
@@ -400,8 +400,8 @@ class TransactionGroupRepository implements TransactionGroupRepositoryInterface
     {
         /** @var TransactionGroupFactory $factory */
         $factory = app(TransactionGroupFactory::class);
-        $factory->setUser($data['user']);
-        $factory->setUserGroup($data['user_group']);
+        $factory->setUser($this->user);
+        $factory->setUserGroup($this->userGroup);
 
         try {
             return $factory->create($data);


### PR DESCRIPTION
### **Fixes**  
This PR fixes issue **#9887**  

### **Changes in this pull request:**  
- Replaced `$data['user']` and `$data['user_group']` with `$this->user` and `$this->userGroup` in **TransactionGroupFactory::create()**  
- Replaced `$data['user']` and `$data['user_group']` with `$this->user` and `$this->userGroup` in **TransactionGroupRepository::store()**  

### **Why this fix is needed:**  
The previous implementation used `$data['user']` and `$data['user_group']`, which led to incorrect handling of user context. This fix ensures the factory and repository classes use the instance variables (`$this->user`, `$this->userGroup`) instead, aligning with the expected behavior.  


---

**@JC5**, please review when you have a chance! 🚀