### PR TITLE
Add support for PHP function `strpos` in expressions

### DIFF
--- a/app/TransactionRules/Expressions/ActionExpressionLanguageProvider.php
+++ b/app/TransactionRules/Expressions/ActionExpressionLanguageProvider.php
@@ -60,6 +60,7 @@ class ActionExpressionLanguageProvider implements ExpressionFunctionProviderInte
 
             ExpressionFunction::fromPhp('substr'),
             ExpressionFunction::fromPhp('strlen'),
+            ExpressionFunction::fromPhp('strpos'),
         ];
     }
 }


### PR DESCRIPTION
Changes in this pull request:
- Add support for PHP function `strpos` in expressions

@JC5
