### PR TITLE
Add Uruguayan peso to currency seeder

### DIFF
--- a/database/seeders/TransactionCurrencySeeder.php
+++ b/database/seeders/TransactionCurrencySeeder.php
@@ -73,6 +73,7 @@ class TransactionCurrencySeeder extends Seeder
         $currencies[] = ['code' => 'ILS', 'name' => 'Israeli new shekel', 'symbol' => '₪', 'decimal_places' => 2];
         $currencies[] = ['code' => 'CHF', 'name' => 'Swiss franc', 'symbol' => 'CHF', 'decimal_places' => 2];
         $currencies[] = ['code' => 'HRK', 'name' => 'Croatian kuna', 'symbol' => 'kn', 'decimal_places' => 2];
+        $currencies[] = ['code' => 'UYU', 'name' => 'Uruguayan peso', 'symbol' => '$U', 'decimal_places' => 2];
 
         foreach ($currencies as $currency) {
             if (null === TransactionCurrency::where('code', $currency['code'])->first()) {


### PR DESCRIPTION
Changes in this pull request:

- Add uruguayan peso

Uruguayan peso is useful to me, since I'm uruguayan. 
I would like this currency to be available in the demo site if possible because its useful to debug issues I found on my own instance of Firefly

Ref: https://en.wikipedia.org/wiki/Uruguayan_peso

(Plan to mirror this PR on main repo later)