### PR TITLE
update check: consider cron succesfull when disabled or too frequent

### DIFF
--- a/app/Support/Cronjobs/UpdateCheckCronjob.php
+++ b/app/Support/Cronjobs/UpdateCheckCronjob.php
@@ -45,8 +45,8 @@ class UpdateCheckCronjob extends AbstractCronjob
             Log::debug('Update check is not enabled.');
             // get stuff from job:
             $this->jobFired     = false;
-            $this->jobErrored   = true;
-            $this->jobSucceeded = false;
+            $this->jobErrored   = false;
+            $this->jobSucceeded = true;
             $this->message      = 'The update check is not enabled.';
 
             return;
@@ -61,8 +61,8 @@ class UpdateCheckCronjob extends AbstractCronjob
         if ($diff < 604800 && false === $this->force) {
             // get stuff from job:
             $this->jobFired     = false;
-            $this->jobErrored   = true;
-            $this->jobSucceeded = false;
+            $this->jobErrored   = false;
+            $this->jobSucceeded = true;
             $this->message      = sprintf('Checked for updates less than a week ago (on %s).', date('Y-m-d H:i:s', $lastCheckTime->data));
 
             return;


### PR DESCRIPTION
If the update check cron is disabled or run more often than once a week consider the cron run succesfull.

<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue #10038.

Changes in this pull request:

- Mark update-check cron as succeeded if update check is disabled
- Mark update-check cron as succeeded if update check run too frequently

@JC5
