### PR TITLE
Reduced minimum password length from 16 to 10 for usability

### DIFF
--- a/app/Http/Requests/ProfileFormRequest.php
+++ b/app/Http/Requests/ProfileFormRequest.php
@@ -43,7 +43,7 @@ class ProfileFormRequest extends FormRequest
         // fixed
         return [
             'current_password'          => 'required',
-            'new_password'              => 'required|confirmed|secure_password|min:16',
+            'new_password'              => 'required|confirmed|secure_password|min:10',
             'new_password_confirmation' => 'required',
         ];
     }


### PR DESCRIPTION
The minimum required password length has been reduced from 16 to 10 characters.

While longer passwords are more secure, requiring 16 characters proved to be impractical for many users. A 10-character minimum strikes a better balance between security and usability, encouraging users to choose strong but manageable passwords.

This change updates the validation rule accordingly.

<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue # (if relevant).

Changes in this pull request:

-
-
-
