### PR TITLE
Add missing preference variable

### DIFF
--- a/app/Handlers/Events/BillEventHandler.php
+++ b/app/Handlers/Events/BillEventHandler.php
@@ -111,7 +111,7 @@ class BillEventHandler
         $bill = $event->bill;
 
         /** @var bool $preference */
-        Preferences::getForUser($bill->user, 'notification_bill_reminder', true)->data;
+        $preference = Preferences::getForUser($bill->user, 'notification_bill_reminder', true)->data;
 
         if (true === $preference) {
             Log::debug('Bill reminder is true!');


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue #10840.

Changes in this pull request:

* Adds back the missing `$preference` variable, which resulted in an exception when Firefly III mailer tried to send an email about a bill.

Related change: https://github.com/firefly-iii/firefly-iii/commit/4dba9cea215c0ee926831d484a1cfc07d36c4cca#diff-4aa3192a4b132c8ec9667947826ee01e9407c6c87553d3697236718b16d838f1R88