### PR TITLE
use correct translation key for category report income table

### DIFF
--- a/resources/views/reports/category/partials/avg-income.twig
+++ b/resources/views/reports/category/partials/avg-income.twig
@@ -2,7 +2,7 @@
     <thead>
     <tr>
         <th data-defaultsign="az">{{ 'account'|_ }}</th>
-        <th data-defaultsign="_19" style="text-align: right;">{{ 'spent_average'|_ }}</th>
+        <th data-defaultsign="_19" style="text-align: right;">{{ 'income_average'|_ }}</th>
         <th data-defaultsign="_19" style="text-align: right;">{{ 'total'|_ }}</th>
         <th data-defaultsign="_19">{{ 'transaction_count'|_ }}</th>
     </tr>


### PR DESCRIPTION
use correct translation key for category report income table. 
The key already exists in the translations, but the incorrect one was used:

```
'spent_average'  => 'Spent (average)',
'income_average' => 'Income (average)',
```