### PR TITLE
Add Uruguayan Peso to currency seeder

### DIFF
--- a/database/seeders/TransactionCurrencySeeder.php
+++ b/database/seeders/TransactionCurrencySeeder.php
@@ -57,6 +57,7 @@ class TransactionCurrencySeeder extends Seeder
         $currencies[] = ['code' => 'ARS', 'name' => 'Argentinian Peso', 'symbol' => '$', 'decimal_places' => 2];
         $currencies[] = ['code' => 'COP', 'name' => 'Colombian Peso', 'symbol' => '$', 'decimal_places' => 2];
         $currencies[] = ['code' => 'CLP', 'name' => 'Chilean Peso', 'symbol' => '$', 'decimal_places' => 2];
+        $currencies[] = ['code' => 'UYU', 'name' => 'Uruguayan Peso', 'symbol' => '$', 'decimal_places' => 2];
 
         // oceanian currencies
         $currencies[] = ['code' => 'IDR', 'name' => 'Indonesian rupiah', 'symbol' => 'Rp', 'decimal_places' => 2];


### PR DESCRIPTION
Adds Uruguayan Peso so it doesn't need to be manually added on new installs and (hopefully) also starts getting regular automated exchange rates.