### PR TITLE
Fix layout overflow issues with long content in v1 and v2 layouts

### DIFF
--- a/public/v1/css/firefly.css
+++ b/public/v1/css/firefly.css
@@ -263,6 +263,10 @@ span.twitter-typeahead {
     background-color: #f5f5f5;
 }
 
+.box-body, .box, .content-header {
+    overflow-x: auto;
+}
+
 /*
 .twitter-typeahead {
     width:100%;

--- a/resources/assets/v2/src/sass/app.scss
+++ b/resources/assets/v2/src/sass/app.scss
@@ -76,7 +76,7 @@ h3.hover-expand:hover {
     overflow-x: auto;
 }
 
-.box-body {
+.box-body, .box, .content-header {
     overflow-x: auto;
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.
- PRs (or parts thereof) that only fix issues inside code comments will not be accepted.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue #11560.
This ensures that containers scroll horizontally instead of breaking the layout when displaying very long transaction descriptions.

Changes in this pull request:

- Added overflow-x: auto to .box-body, .box, and .content-header classes in the v1 CSS (firefly.css).
- Added overflow-x: auto to the same classes in the v2 SCSS (app.scss).
