### PR TITLE
Convert to primary currency for category charts

### DIFF
--- a/app/Http/Controllers/Chart/CategoryReportController.php
+++ b/app/Http/Controllers/Chart/CategoryReportController.php
@@ -29,8 +29,8 @@ use FireflyIII\Http\Controllers\Controller;
 use FireflyIII\Models\Category;
 use FireflyIII\Repositories\Category\OperationsRepositoryInterface;
 use FireflyIII\Support\Facades\Navigation;
-use FireflyIII\Support\Facades\Steam;
 use FireflyIII\Support\Http\Controllers\AugumentData;
+use FireflyIII\Support\Http\Controllers\ResolvesJournalAmountAndCurrency;
 use FireflyIII\Support\Http\Controllers\TransactionCalculation;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
@@ -43,6 +43,7 @@ use Illuminate\Support\Collection;
 class CategoryReportController extends Controller
 {
     use AugumentData;
+    use ResolvesJournalAmountAndCurrency;
     use TransactionCalculation;
 
     private GeneratorInterface $generator;
@@ -73,15 +74,15 @@ class CategoryReportController extends Controller
             /** @var array $category */
             foreach ($currency['categories'] as $category) {
                 foreach ($category['transaction_journals'] as $journal) {
+                    $journalData              = $this->resolveJournalAmountAndCurrency($journal, $currency);
                     $objectName               = $journal['budget_name'] ?? trans('firefly.no_budget');
-                    $title                    = sprintf('%s (%s)', $objectName, $currency['currency_name']);
+                    $title                    = sprintf('%s (%s)', $objectName, $journalData['currency_name']);
                     $result[$title] ??= [
                         'amount'          => '0',
-                        'currency_symbol' => $currency['currency_symbol'],
-                        'currency_code'   => $currency['currency_code'],
+                        'currency_symbol' => $journalData['currency_symbol'],
+                        'currency_code'   => $journalData['currency_code'],
                     ];
-                    $amount                   = Steam::positive($journal['amount']);
-                    $result[$title]['amount'] = bcadd($result[$title]['amount'], $amount);
+                    $result[$title]['amount'] = bcadd($result[$title]['amount'], $journalData['amount']);
                 }
             }
         }
@@ -100,15 +101,15 @@ class CategoryReportController extends Controller
         foreach ($spent as $currency) {
             /** @var array $category */
             foreach ($currency['categories'] as $category) {
-                $title = sprintf('%s (%s)', $category['name'], $currency['currency_name']);
-                $result[$title] ??= [
-                    'amount'          => '0',
-                    'currency_symbol' => $currency['currency_symbol'],
-                    'currency_code'   => $currency['currency_code'],
-                ];
                 foreach ($category['transaction_journals'] as $journal) {
-                    $amount                   = Steam::positive($journal['amount']);
-                    $result[$title]['amount'] = bcadd($result[$title]['amount'], $amount);
+                    $journalData = $this->resolveJournalAmountAndCurrency($journal, $currency);
+                    $title       = sprintf('%s (%s)', $category['name'], $journalData['currency_name']);
+                    $result[$title] ??= [
+                        'amount'          => '0',
+                        'currency_symbol' => $journalData['currency_symbol'],
+                        'currency_code'   => $journalData['currency_code'],
+                    ];
+                    $result[$title]['amount'] = bcadd($result[$title]['amount'], $journalData['amount']);
                 }
             }
         }
@@ -127,15 +128,15 @@ class CategoryReportController extends Controller
         foreach ($earned as $currency) {
             /** @var array $category */
             foreach ($currency['categories'] as $category) {
-                $title = sprintf('%s (%s)', $category['name'], $currency['currency_name']);
-                $result[$title] ??= [
-                    'amount'          => '0',
-                    'currency_symbol' => $currency['currency_symbol'],
-                    'currency_code'   => $currency['currency_code'],
-                ];
                 foreach ($category['transaction_journals'] as $journal) {
-                    $amount                   = Steam::positive($journal['amount']);
-                    $result[$title]['amount'] = bcadd($result[$title]['amount'], $amount);
+                    $journalData = $this->resolveJournalAmountAndCurrency($journal, $currency);
+                    $title       = sprintf('%s (%s)', $category['name'], $journalData['currency_name']);
+                    $result[$title] ??= [
+                        'amount'          => '0',
+                        'currency_symbol' => $journalData['currency_symbol'],
+                        'currency_code'   => $journalData['currency_code'],
+                    ];
+                    $result[$title]['amount'] = bcadd($result[$title]['amount'], $journalData['amount']);
                 }
             }
         }
@@ -155,15 +156,15 @@ class CategoryReportController extends Controller
             /** @var array $category */
             foreach ($currency['categories'] as $category) {
                 foreach ($category['transaction_journals'] as $journal) {
+                    $journalData              = $this->resolveJournalAmountAndCurrency($journal, $currency);
                     $objectName               = $journal['destination_account_name'] ?? trans('firefly.empty');
-                    $title                    = sprintf('%s (%s)', $objectName, $currency['currency_name']);
+                    $title                    = sprintf('%s (%s)', $objectName, $journalData['currency_name']);
                     $result[$title] ??= [
                         'amount'          => '0',
-                        'currency_symbol' => $currency['currency_symbol'],
-                        'currency_code'   => $currency['currency_code'],
+                        'currency_symbol' => $journalData['currency_symbol'],
+                        'currency_code'   => $journalData['currency_code'],
                     ];
-                    $amount                   = Steam::positive($journal['amount']);
-                    $result[$title]['amount'] = bcadd($result[$title]['amount'], $amount);
+                    $result[$title]['amount'] = bcadd($result[$title]['amount'], $journalData['amount']);
                 }
             }
         }
@@ -183,15 +184,15 @@ class CategoryReportController extends Controller
             /** @var array $category */
             foreach ($currency['categories'] as $category) {
                 foreach ($category['transaction_journals'] as $journal) {
+                    $journalData              = $this->resolveJournalAmountAndCurrency($journal, $currency);
                     $objectName               = $journal['destination_account_name'] ?? trans('firefly.empty');
-                    $title                    = sprintf('%s (%s)', $objectName, $currency['currency_name']);
+                    $title                    = sprintf('%s (%s)', $objectName, $journalData['currency_name']);
                     $result[$title] ??= [
                         'amount'          => '0',
-                        'currency_symbol' => $currency['currency_symbol'],
-                        'currency_code'   => $currency['currency_code'],
+                        'currency_symbol' => $journalData['currency_symbol'],
+                        'currency_code'   => $journalData['currency_code'],
                     ];
-                    $amount                   = Steam::positive($journal['amount']);
-                    $result[$title]['amount'] = bcadd($result[$title]['amount'], $amount);
+                    $result[$title]['amount'] = bcadd($result[$title]['amount'], $journalData['amount']);
                 }
             }
         }
@@ -210,26 +211,25 @@ class CategoryReportController extends Controller
         // loop expenses.
         foreach ($spent as $currency) {
             // add things to chart Data for each currency:
-            $spentKey = sprintf('%d-spent', $currency['currency_id']);
-            $chartData[$spentKey] ??= [
-                'label'           => sprintf(
-                    '%s (%s)',
-                    (string) trans('firefly.spent_in_specific_category', ['category' => $category->name]),
-                    $currency['currency_name']
-                ),
-                'type'            => 'bar',
-                'currency_symbol' => $currency['currency_symbol'],
-                'currency_code'   => $currency['currency_code'],
-                'currency_id'     => $currency['currency_id'],
-                'entries'         => $this->makeEntries($start, $end),
-            ];
-
             foreach ($currency['categories'] as $currentCategory) {
                 foreach ($currentCategory['transaction_journals'] as $journal) {
-                    $key                                   = $journal['date']->isoFormat($format);
-                    $amount                                = Steam::positive($journal['amount']);
+                    $journalData = $this->resolveJournalAmountAndCurrency($journal, $currency);
+                    $spentKey    = sprintf('%d-spent', $journalData['currency_id']);
+                    $chartData[$spentKey] ??= [
+                        'label'           => sprintf(
+                            '%s (%s)',
+                            (string) trans('firefly.spent_in_specific_category', ['category' => $category->name]),
+                            $journalData['currency_name']
+                        ),
+                        'type'            => 'bar',
+                        'currency_symbol' => $journalData['currency_symbol'],
+                        'currency_code'   => $journalData['currency_code'],
+                        'currency_id'     => $journalData['currency_id'],
+                        'entries'         => $this->makeEntries($start, $end),
+                    ];
+                    $key                    = $journal['date']->isoFormat($format);
                     $chartData[$spentKey]['entries'][$key] ??= '0';
-                    $chartData[$spentKey]['entries'][$key] = bcadd($chartData[$spentKey]['entries'][$key], $amount);
+                    $chartData[$spentKey]['entries'][$key] = bcadd($chartData[$spentKey]['entries'][$key], $journalData['amount']);
                 }
             }
         }
@@ -237,26 +237,25 @@ class CategoryReportController extends Controller
         // loop income.
         foreach ($earned as $currency) {
             // add things to chart Data for each currency:
-            $spentKey = sprintf('%d-earned', $currency['currency_id']);
-            $chartData[$spentKey] ??= [
-                'label'           => sprintf(
-                    '%s (%s)',
-                    (string) trans('firefly.earned_in_specific_category', ['category' => $category->name]),
-                    $currency['currency_name']
-                ),
-                'type'            => 'bar',
-                'currency_symbol' => $currency['currency_symbol'],
-                'currency_code'   => $currency['currency_code'],
-                'currency_id'     => $currency['currency_id'],
-                'entries'         => $this->makeEntries($start, $end),
-            ];
-
             foreach ($currency['categories'] as $currentCategory) {
                 foreach ($currentCategory['transaction_journals'] as $journal) {
-                    $key                                   = $journal['date']->isoFormat($format);
-                    $amount                                = Steam::positive($journal['amount']);
+                    $journalData = $this->resolveJournalAmountAndCurrency($journal, $currency);
+                    $spentKey    = sprintf('%d-earned', $journalData['currency_id']);
+                    $chartData[$spentKey] ??= [
+                        'label'           => sprintf(
+                            '%s (%s)',
+                            (string) trans('firefly.earned_in_specific_category', ['category' => $category->name]),
+                            $journalData['currency_name']
+                        ),
+                        'type'            => 'bar',
+                        'currency_symbol' => $journalData['currency_symbol'],
+                        'currency_code'   => $journalData['currency_code'],
+                        'currency_id'     => $journalData['currency_id'],
+                        'entries'         => $this->makeEntries($start, $end),
+                    ];
+                    $key                    = $journal['date']->isoFormat($format);
                     $chartData[$spentKey]['entries'][$key] ??= '0';
-                    $chartData[$spentKey]['entries'][$key] = bcadd($chartData[$spentKey]['entries'][$key], $amount);
+                    $chartData[$spentKey]['entries'][$key] = bcadd($chartData[$spentKey]['entries'][$key], $journalData['amount']);
                 }
             }
         }
@@ -276,15 +275,15 @@ class CategoryReportController extends Controller
             /** @var array $category */
             foreach ($currency['categories'] as $category) {
                 foreach ($category['transaction_journals'] as $journal) {
+                    $journalData              = $this->resolveJournalAmountAndCurrency($journal, $currency);
                     $objectName               = $journal['source_account_name'] ?? trans('firefly.empty');
-                    $title                    = sprintf('%s (%s)', $objectName, $currency['currency_name']);
+                    $title                    = sprintf('%s (%s)', $objectName, $journalData['currency_name']);
                     $result[$title] ??= [
                         'amount'          => '0',
-                        'currency_symbol' => $currency['currency_symbol'],
-                        'currency_code'   => $currency['currency_code'],
+                        'currency_symbol' => $journalData['currency_symbol'],
+                        'currency_code'   => $journalData['currency_code'],
                     ];
-                    $amount                   = Steam::positive($journal['amount']);
-                    $result[$title]['amount'] = bcadd($result[$title]['amount'], $amount);
+                    $result[$title]['amount'] = bcadd($result[$title]['amount'], $journalData['amount']);
                 }
             }
         }
@@ -304,15 +303,15 @@ class CategoryReportController extends Controller
             /** @var array $category */
             foreach ($currency['categories'] as $category) {
                 foreach ($category['transaction_journals'] as $journal) {
+                    $journalData              = $this->resolveJournalAmountAndCurrency($journal, $currency);
                     $objectName               = $journal['source_account_name'] ?? trans('firefly.empty');
-                    $title                    = sprintf('%s (%s)', $objectName, $currency['currency_name']);
+                    $title                    = sprintf('%s (%s)', $objectName, $journalData['currency_name']);
                     $result[$title] ??= [
                         'amount'          => '0',
-                        'currency_symbol' => $currency['currency_symbol'],
-                        'currency_code'   => $currency['currency_code'],
+                        'currency_symbol' => $journalData['currency_symbol'],
+                        'currency_code'   => $journalData['currency_code'],
                     ];
-                    $amount                   = Steam::positive($journal['amount']);
-                    $result[$title]['amount'] = bcadd($result[$title]['amount'], $amount);
+                    $result[$title]['amount'] = bcadd($result[$title]['amount'], $journalData['amount']);
                 }
             }
         }
@@ -341,4 +340,5 @@ class CategoryReportController extends Controller
 
         return $return;
     }
+
 }

--- a/app/Http/Controllers/Chart/ReportController.php
+++ b/app/Http/Controllers/Chart/ReportController.php
@@ -36,6 +36,7 @@ use FireflyIII\Support\Facades\Navigation;
 use FireflyIII\Support\Facades\Steam;
 use FireflyIII\Support\Http\Controllers\BasicDataSupport;
 use FireflyIII\Support\Http\Controllers\ChartGeneration;
+use FireflyIII\Support\Http\Controllers\ResolvesJournalAmountAndCurrency;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
@@ -47,6 +48,7 @@ class ReportController extends Controller
 {
     use BasicDataSupport;
     use ChartGeneration;
+    use ResolvesJournalAmountAndCurrency;
 
     protected GeneratorInterface $generator;
 
@@ -176,22 +178,14 @@ class ReportController extends Controller
         // loop. group by currency and by period.
         /** @var array $journal */
         foreach ($journals as $journal) {
-            $period                           = $journal['date']->format($format);
-            $currencyId                       = (int) $journal['currency_id'];
-            $currencySymbol                   = (string) $journal['currency_symbol'];
-            $currencyCode                     = (string) $journal['currency_code'];
-            $currencyName                     = (string) $journal['currency_name'];
-            $currencyDecimalPlaces            = (int) $journal['currency_decimal_places'];
-            $amount                           = (string) $journal['amount'];
-
-            if ($this->convertToPrimary && null !== $this->primaryCurrency && $journal['currency_id'] !== $this->primaryCurrency->id) {
-                $currencyId            = $this->primaryCurrency->id;
-                $currencySymbol        = $this->primaryCurrency->symbol;
-                $currencyCode          = $this->primaryCurrency->code;
-                $currencyName          = $this->primaryCurrency->name;
-                $currencyDecimalPlaces = $this->primaryCurrency->decimal_places;
-                $amount                = $journal['foreign_currency_id'] === $this->primaryCurrency->id ? $journal['foreign_amount'] : $journal['pc_amount'];
-            }
+            $period      = $journal['date']->format($format);
+            $journalData = $this->resolveJournalAmountAndCurrency($journal, $journal);
+            $currencyId            = $journalData['currency_id'];
+            $currencySymbol        = $journalData['currency_symbol'];
+            $currencyCode          = $journalData['currency_code'];
+            $currencyName          = $journalData['currency_name'];
+            $currencyDecimalPlaces = $journalData['currency_decimal_places'];
+            $amount                = $journalData['amount'];
 
             $data[$currencyId]          ??= [
                 'currency_id'             => $currencyId,
@@ -202,8 +196,7 @@ class ReportController extends Controller
             ];
             $data[$currencyId][$period] ??= ['period' => $period, 'spent'  => '0', 'earned' => '0'];
             // in our outgoing?
-            $key                              = 'spent';
-            $amount                           = Steam::positive($amount);
+            $key = 'spent';
 
             // deposit = incoming
             // transfer or reconcile or opening balance, and these accounts are the destination.

--- a/app/Support/Http/Controllers/ResolvesJournalAmountAndCurrency.php
+++ b/app/Support/Http/Controllers/ResolvesJournalAmountAndCurrency.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * ResolvesJournalAmountAndCurrency.php
+ * Copyright (c) 2026 james@firefly-iii.org
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace FireflyIII\Support\Http\Controllers;
+
+use FireflyIII\Support\Facades\Steam;
+
+trait ResolvesJournalAmountAndCurrency
+{
+    /**
+     * Normalize journal currency metadata and positive amount, honoring primary currency conversion.
+     */
+    protected function resolveJournalAmountAndCurrency(array $journal, array $currency): array
+    {
+        $currencyId            = (int) ($journal['currency_id'] ?? $currency['currency_id']);
+        $currencyName          = (string) ($journal['currency_name'] ?? $currency['currency_name']);
+        $currencySymbol        = (string) ($journal['currency_symbol'] ?? $currency['currency_symbol']);
+        $currencyCode          = (string) ($journal['currency_code'] ?? $currency['currency_code']);
+        $currencyDecimalPlaces = (int) ($journal['currency_decimal_places'] ?? $currency['currency_decimal_places'] ?? 2);
+        $amount                = (string) $journal['amount'];
+
+        if (
+            $this->convertToPrimary
+            && null !== $this->primaryCurrency
+            && $currencyId !== $this->primaryCurrency->id
+        ) {
+            $currencyId            = $this->primaryCurrency->id;
+            $currencyName          = $this->primaryCurrency->name;
+            $currencySymbol        = $this->primaryCurrency->symbol;
+            $currencyCode          = $this->primaryCurrency->code;
+            $currencyDecimalPlaces = $this->primaryCurrency->decimal_places;
+            $amount                = (int) ($journal['foreign_currency_id'] ?? 0) === $this->primaryCurrency->id
+                ? (string) ($journal['foreign_amount'] ?? '0')
+                : (string) ($journal['pc_amount'] ?? '0')
+            ;
+        }
+
+        return [
+            'currency_id'             => $currencyId,
+            'currency_name'           => $currencyName,
+            'currency_symbol'         => $currencySymbol,
+            'currency_code'           => $currencyCode,
+            'currency_decimal_places' => $currencyDecimalPlaces,
+            'amount'                  => Steam::positive($amount),
+        ];
+    }
+}


### PR DESCRIPTION
<!--

Please TALK TO ME FIRST before you open a PR.

1. If you fix a problem that has no ticket, talk to me FIRST.
2. If you  introduce new financial solutions or concepts, talk to me FIRST.
3. If your PR is more than 25 lines, talk to me FIRST.
4. If you used AI to write your PR, talk to me FIRST.
5. If you fix spelling or code comments, talk to me FIRST.

Wanna talk to me? Open a GitHub Issue, Discussion, or send me an email: james@firefly-iii.org

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->

@JC5 
    
This PR fixes issue #11806 

Changes in this pull request:

- Convert to primary currency (if enabled) for pie charts and main chart in Category Report page
-
-
