### PR TITLE
Return currency info for tag journals

### DIFF
--- a/app/Repositories/Tag/OperationsRepository.php
+++ b/app/Repositories/Tag/OperationsRepository.php
@@ -95,6 +95,14 @@ class OperationsRepository implements OperationsRepositoryInterface, UserGroupIn
 
                 $array[$currencyId]['tags'][$tagId]['transaction_journals'][$journalId] = [
                     'amount'                   => Steam::negative($journal['amount']),
+                    'currency_id'              => (int) $journal['currency_id'],
+                    'currency_name'            => (string) $journal['currency_name'],
+                    'currency_symbol'          => (string) $journal['currency_symbol'],
+                    'currency_code'            => (string) $journal['currency_code'],
+                    'currency_decimal_places'  => (int) $journal['currency_decimal_places'],
+                    'foreign_currency_id'      => (int) ($journal['foreign_currency_id'] ?? 0),
+                    'foreign_amount'           => isset($journal['foreign_amount']) ? Steam::negative((string) $journal['foreign_amount']) : null,
+                    'pc_amount'                => isset($journal['pc_amount']) ? Steam::negative((string) $journal['pc_amount']) : null,
                     'date'                     => $journal['date'],
                     'source_account_id'        => $journal['source_account_id'],
                     'budget_name'              => $journal['budget_name'],
@@ -172,6 +180,14 @@ class OperationsRepository implements OperationsRepositoryInterface, UserGroupIn
                 $journalId                                                              = (int) $journal['transaction_journal_id'];
                 $array[$currencyId]['tags'][$tagId]['transaction_journals'][$journalId] = [
                     'amount'                   => Steam::positive($journal['amount']),
+                    'currency_id'              => (int) $journal['currency_id'],
+                    'currency_name'            => (string) $journal['currency_name'],
+                    'currency_symbol'          => (string) $journal['currency_symbol'],
+                    'currency_code'            => (string) $journal['currency_code'],
+                    'currency_decimal_places'  => (int) $journal['currency_decimal_places'],
+                    'foreign_currency_id'      => (int) ($journal['foreign_currency_id'] ?? 0),
+                    'foreign_amount'           => isset($journal['foreign_amount']) ? Steam::positive((string) $journal['foreign_amount']) : null,
+                    'pc_amount'                => isset($journal['pc_amount']) ? Steam::positive((string) $journal['pc_amount']) : null,
                     'date'                     => $journal['date'],
                     'source_account_id'        => $journal['source_account_id'],
                     'budget_name'              => $journal['budget_name'],


### PR DESCRIPTION
<!--

Please TALK TO ME FIRST before you open a PR.

1. If you fix a problem that has no ticket, talk to me FIRST.
2. If you  introduce new financial solutions or concepts, talk to me FIRST.
3. If your PR is more than 25 lines, talk to me FIRST.
4. If you used AI to write your PR, talk to me FIRST.
5. If you fix spelling or code comments, talk to me FIRST.

Wanna talk to me? Open a GitHub Issue, Discussion, or send me an email: james@firefly-iii.org

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->

@JC5 
    
This PR fixes issue #11806 

Fix PR #11835 - This PR tries to convert journal to primary currency, but missing the relevant fields

Changes in this pull request:

- PR #11835 tries to convert journal to primary currency, but missing the relevant fields
-
-
