### PR TITLE
Avoid loading entire dtatabase into memory

### DIFF
--- a/app/Console/Commands/Correction/CorrectsGroupAccounts.php
+++ b/app/Console/Commands/Correction/CorrectsGroupAccounts.php
@@ -59,12 +59,12 @@ class CorrectsGroupAccounts extends Command
         $flags->applyRules        = false;
         $flags->fireWebhooks      = false;
         $flags->recalculateCredit = true;
-        $objects                  = new TransactionGroupEventObjects();
         foreach ($groups as $groupId) {
-            $group = TransactionGroup::find($groupId);
-            $objects->appendFromTransactionGroup($group);
+            $group  = TransactionGroup::find($groupId);
+            $object = new TransactionGroupEventObjects();
+            $object->appendFromTransactionGroup($group);
+            event(new UpdatedSingleTransactionGroup($flags, $object));
         }
-        event(new UpdatedSingleTransactionGroup($flags, $objects));
         event(new WebhookMessagesRequestSending());
 
         return 0;


### PR DESCRIPTION
<!--

Please TALK TO ME FIRST before you open a PR.

1. If you fix a problem that has no ticket, talk to me FIRST.
2. If you  introduce new financial solutions or concepts, talk to me FIRST.
3. If your PR is more than 25 lines, talk to me FIRST.
4. If you used AI to write your PR, talk to me FIRST.
5. If you fix spelling or code comments, talk to me FIRST.

Wanna talk to me? Open a GitHub Issue, Discussion, or send me an email: james@firefly-iii.org

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->

@JC5 
    
This PR fixes issue #11810.

Changes in this pull request:

- emits `UpdatedSingleTransactionGroup` event in `CorrectsGroupAccounts` once per `TransactionGroup` to avoid loading entire database into memory.

Pros: Reduces memory usage from >500M to ~150M (Depends on number of transaction groups added to `TransactionGroupEventObjects`. Tested with 2,942 groups.

Tradeoff: Recalculates credit for account multiple times.
