### PR TITLE
Fix typo in SMTP server comment in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,7 +173,7 @@ MAIL_ENCRYPTION=null
 MAIL_SENDMAIL_COMMAND=
 
 #
-# If you use self-signed certificates for your STMP server, you can use the following settings.
+# If you use self-signed certificates for your SMTP server, you can use the following settings.
 #
 MAIL_ALLOW_SELF_SIGNED=false
 MAIL_VERIFY_PEER=true


### PR DESCRIPTION
<!--

Please TALK TO ME FIRST before you open a PR.

1. If you fix a problem that has no ticket, talk to me FIRST.
2. If you  introduce new financial solutions or concepts, talk to me FIRST.
3. If your PR is more than 25 lines, talk to me FIRST.
4. If you used AI to write your PR, talk to me FIRST.
5. If you fix spelling or code comments, talk to me FIRST.

Wanna talk to me? Open a GitHub Issue, Discussion, or send me an email: james@firefly-iii.org

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->

@JC5 
    
This PR fixes issue #11970.

Changes in this pull request:

- Fixed SMTP typo in `.env.example`.
