### PR TITLE
fix: Typo STMP -> SMTP in env comment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,7 +173,7 @@ MAIL_ENCRYPTION=null
 MAIL_SENDMAIL_COMMAND=
 
 #
-# If you use self-signed certificates for your STMP server, you can use the following settings.
+# If you use self-signed certificates for your SMTP server, you can use the following settings.
 #
 MAIL_ALLOW_SELF_SIGNED=false
 MAIL_VERIFY_PEER=true


### PR DESCRIPTION
Fixes #11970

Corrects a typo in `.env.example` line 176 where `STMP` was written instead of `SMTP` in the comment describing self-signed certificate settings for the mail server. Simple transcription error with no functional impact.