### PR TITLE
fix: refresh foreign currency valuations when rates change

### DIFF
--- a/app/Api/V1/Controllers/Chart/AccountController.php
+++ b/app/Api/V1/Controllers/Chart/AccountController.php
@@ -37,6 +37,7 @@ use FireflyIII\Support\Facades\Steam;
 use FireflyIII\Support\Http\Api\ApiSupport;
 use FireflyIII\Support\Http\Api\CleansChartData;
 use FireflyIII\Support\Http\Api\CollectsAccountsFromFilter;
+use FireflyIII\Support\Http\Api\ExchangeRateConverter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -76,6 +77,7 @@ final class AccountController extends Controller
      */
     public function overview(ChartRequest $request): JsonResponse
     {
+        $this->chartData = [];
         $queryParameters = $request->getParameters();
         $accounts        = $this->getAccountList($queryParameters);
 
@@ -104,6 +106,7 @@ final class AccountController extends Controller
         $currentStart      = clone $params['start'];
         $range             = Steam::finalAccountBalanceInRange($account, $params['start'], clone $params['end'], $this->convertToPrimary);
         $period            = $params['period'] ?? '1D';
+        $converter         = new ExchangeRateConverter();
 
         $previous          = array_values($range)[0]['balance'];
         $pcPrevious        = null;
@@ -162,7 +165,11 @@ final class AccountController extends Controller
 
             $currentSet['entries'][$label] = $previous;
             if ($this->convertToPrimary) {
-                $currentSet['pc_entries'][$label] = $pcPrevious;
+                $pcValue = $pcPrevious;
+                if ($currency->id !== $this->primaryCurrency->id && is_string($previous)) {
+                    $pcValue = $converter->convert($currency, $this->primaryCurrency, $currentStart, $previous);
+                }
+                $currentSet['pc_entries'][$label] = $pcValue;
             }
 
             $currentStart                  = Navigation::addPeriod($currentStart, $period);

--- a/app/Repositories/Currency/CurrencyRepository.php
+++ b/app/Repositories/Currency/CurrencyRepository.php
@@ -38,6 +38,7 @@ use FireflyIII\Models\TransactionCurrency;
 use FireflyIII\Repositories\User\UserRepositoryInterface;
 use FireflyIII\Services\Internal\Destroy\CurrencyDestroyService;
 use FireflyIII\Services\Internal\Update\CurrencyUpdateService;
+use FireflyIII\Support\ExchangeRate\ExchangeRateCacheInvalidation;
 use FireflyIII\Support\Facades\Amount;
 use FireflyIII\Support\Repositories\UserGroup\UserGroupInterface;
 use FireflyIII\Support\Repositories\UserGroup\UserGroupTrait;
@@ -362,7 +363,7 @@ class CurrencyRepository implements CurrencyRepositoryInterface, UserGroupInterf
             ->currencyExchangeRates()
             ->where('from_currency_id', $fromCurrency->id)
             ->where('to_currency_id', $toCurrency->id)
-            ->where('date', $date->format('Y-m-d'))
+            ->whereDate('date', $date->format('Y-m-d'))
             ->first()
         ;
         if (null !== $rate) {
@@ -410,7 +411,8 @@ class CurrencyRepository implements CurrencyRepositoryInterface, UserGroupInterf
      */
     public function setExchangeRate(TransactionCurrency $fromCurrency, TransactionCurrency $toCurrency, Carbon $date, float $rate): CurrencyExchangeRate
     {
-        return CurrencyExchangeRate::create([
+        $date         = $date->clone()->startOfDay();
+        $exchangeRate = CurrencyExchangeRate::create([
             'user_id'          => $this->user->id,
             'user_group_id'    => $this->userGroup->id,
             'from_currency_id' => $fromCurrency->id,
@@ -419,6 +421,12 @@ class CurrencyRepository implements CurrencyRepositoryInterface, UserGroupInterf
             'date_tz'          => $date->format('e'),
             'rate'             => $rate,
         ]);
+
+        /** @var ExchangeRateCacheInvalidation $service */
+        $service = app(ExchangeRateCacheInvalidation::class);
+        $service->invalidate($this->userGroup);
+
+        return $exchangeRate;
     }
 
     /**

--- a/app/Repositories/ExchangeRate/ExchangeRateRepository.php
+++ b/app/Repositories/ExchangeRate/ExchangeRateRepository.php
@@ -27,6 +27,7 @@ namespace FireflyIII\Repositories\ExchangeRate;
 use Carbon\Carbon;
 use FireflyIII\Models\CurrencyExchangeRate;
 use FireflyIII\Models\TransactionCurrency;
+use FireflyIII\Support\ExchangeRate\ExchangeRateCacheInvalidation;
 use FireflyIII\Support\Repositories\UserGroup\UserGroupInterface;
 use FireflyIII\Support\Repositories\UserGroup\UserGroupTrait;
 use Illuminate\Database\Eloquent\Builder;
@@ -45,6 +46,7 @@ class ExchangeRateRepository implements ExchangeRateRepositoryInterface, UserGro
             ->where('id', $rate->id)
             ->delete()
         ;
+        $this->invalidateCaches();
     }
 
     public function deleteRates(TransactionCurrency $from, TransactionCurrency $to): void
@@ -55,6 +57,7 @@ class ExchangeRateRepository implements ExchangeRateRepositoryInterface, UserGro
             ->where('to_currency_id', $to->id)
             ->delete()
         ;
+        $this->invalidateCaches();
     }
 
     #[Override]
@@ -93,7 +96,7 @@ class ExchangeRateRepository implements ExchangeRateRepositoryInterface, UserGro
             ->currencyExchangeRates()
             ->where('from_currency_id', $from->id)
             ->where('to_currency_id', $to->id)
-            ->where('date', $date->format('Y-m-d'))
+            ->whereDate('date', $date->format('Y-m-d'))
             ->first()
         ;
     }
@@ -101,6 +104,7 @@ class ExchangeRateRepository implements ExchangeRateRepositoryInterface, UserGro
     #[Override]
     public function storeExchangeRate(TransactionCurrency $from, TransactionCurrency $to, string $rate, Carbon $date): CurrencyExchangeRate
     {
+        $date                     = $date->clone()->startOfDay();
         $object                   = new CurrencyExchangeRate();
         $object->user_id          = auth()->user()->id;
         $object->user_group_id    = $this->userGroup->id;
@@ -110,6 +114,7 @@ class ExchangeRateRepository implements ExchangeRateRepositoryInterface, UserGro
         $object->date             = $date;
         $object->date_tz          = $date->format('e');
         $object->save();
+        $this->invalidateCaches();
 
         return $object;
     }
@@ -119,10 +124,18 @@ class ExchangeRateRepository implements ExchangeRateRepositoryInterface, UserGro
     {
         $object->rate = $rate;
         if ($date instanceof Carbon) {
-            $object->date = $date;
+            $object->date = $date->clone()->startOfDay();
         }
         $object->save();
+        $this->invalidateCaches();
 
         return $object;
+    }
+
+    private function invalidateCaches(): void
+    {
+        /** @var ExchangeRateCacheInvalidation $service */
+        $service = app(ExchangeRateCacheInvalidation::class);
+        $service->invalidate($this->userGroup);
     }
 }

--- a/app/Support/ExchangeRate/ExchangeRateCacheInvalidation.php
+++ b/app/Support/ExchangeRate/ExchangeRateCacheInvalidation.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FireflyIII\Support\ExchangeRate;
+
+use FireflyIII\Models\GroupMembership;
+use FireflyIII\Models\UserGroup;
+use FireflyIII\Support\Facades\FireflyConfig;
+use FireflyIII\Support\Facades\Preferences;
+use FireflyIII\Support\Singleton\PreferencesSingleton;
+
+class ExchangeRateCacheInvalidation
+{
+    public function getVersion(UserGroup $userGroup): string
+    {
+        return (string) FireflyConfig::get($this->getVersionKey($userGroup), '0')?->data;
+    }
+
+    public function invalidate(UserGroup $userGroup): void
+    {
+        FireflyConfig::set($this->getVersionKey($userGroup), (string) microtime(true));
+
+        foreach (GroupMembership::with('user')->where('user_group_id', $userGroup->id)->get() as $membership) {
+            if (null === $membership->user) {
+                continue;
+            }
+            Preferences::setForUser($membership->user, 'lastActivity', microtime(true));
+        }
+
+        PreferencesSingleton::getInstance()->resetPreferences();
+    }
+
+    private function getVersionKey(UserGroup $userGroup): string
+    {
+        return sprintf('exchange_rate_cache_version_%d', $userGroup->id);
+    }
+}

--- a/app/Support/Http/Api/ExchangeRateConverter.php
+++ b/app/Support/Http/Api/ExchangeRateConverter.php
@@ -29,6 +29,7 @@ use FireflyIII\Exceptions\FireflyException;
 use FireflyIII\Models\CurrencyExchangeRate;
 use FireflyIII\Models\TransactionCurrency;
 use FireflyIII\Models\UserGroup;
+use FireflyIII\Support\ExchangeRate\ExchangeRateCacheInvalidation;
 use FireflyIII\Support\CacheProperties;
 use FireflyIII\Support\Facades\Amount;
 use FireflyIII\Support\Facades\FireflyConfig;
@@ -115,7 +116,14 @@ class ExchangeRateConverter
 
     private function getCacheKey(TransactionCurrency $from, TransactionCurrency $to, Carbon $date): string
     {
-        return sprintf('cer-%d-%d-%s', $from->id, $to->id, $date->format('Y-m-d'));
+        return sprintf(
+            'cer-%d-%d-%s-group-%d-v-%s',
+            $from->id,
+            $to->id,
+            $date->format('Y-m-d'),
+            $this->userGroup->id,
+            $this->getRateCacheVersion()
+        );
     }
 
     /**
@@ -178,7 +186,7 @@ class ExchangeRateConverter
 
             return '1';
         }
-        $key          = sprintf('cer-%d-%d-%s', $from, $to, $date);
+        $key          = sprintf('cer-%d-%d-%s-group-%d-v-%s', $from, $to, $date, $this->userGroup->id, $this->getRateCacheVersion());
 
         // perhaps the rate has been cached during this particular run
         $preparedRate = $this->prepared[$date][$from][$to] ?? null;
@@ -205,7 +213,7 @@ class ExchangeRateConverter
             ->currencyExchangeRates()
             ->where('from_currency_id', $from)
             ->where('to_currency_id', $to)
-            ->where('date', '<=', $date)
+            ->whereDate('date', '<=', $date)
             ->orderBy('date', 'DESC')
             ->first()
         ;
@@ -284,5 +292,13 @@ class ExchangeRateConverter
         Cache::forever($key, $rate);
 
         return $rate;
+    }
+
+    private function getRateCacheVersion(): string
+    {
+        /** @var ExchangeRateCacheInvalidation $service */
+        $service = app(ExchangeRateCacheInvalidation::class);
+
+        return $service->getVersion($this->userGroup);
     }
 }

--- a/app/Support/Http/Controllers/ChartGeneration.php
+++ b/app/Support/Http/Controllers/ChartGeneration.php
@@ -28,10 +28,13 @@ use Carbon\Carbon;
 use FireflyIII\Exceptions\FireflyException;
 use FireflyIII\Generator\Chart\Basic\GeneratorInterface;
 use FireflyIII\Models\Account;
+use FireflyIII\Models\TransactionCurrency;
 use FireflyIII\Repositories\Account\AccountRepositoryInterface;
 use FireflyIII\Support\CacheProperties;
+use FireflyIII\Support\ExchangeRate\ExchangeRateCacheInvalidation;
 use FireflyIII\Support\Facades\Amount;
 use FireflyIII\Support\Facades\Steam;
+use FireflyIII\Support\Http\Api\ExchangeRateConverter;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 
@@ -55,6 +58,11 @@ trait ChartGeneration
         $cache->addProperty('chart.account.account-balance-chart');
         $cache->addProperty($accounts);
         $cache->addProperty($convertToPrimary);
+        if ($convertToPrimary && auth()->check()) {
+            /** @var ExchangeRateCacheInvalidation $invalidation */
+            $invalidation = app(ExchangeRateCacheInvalidation::class);
+            $cache->addProperty($invalidation->getVersion(auth()->user()->userGroup));
+        }
         if ($cache->has()) {
             return $cache->get();
         }
@@ -75,24 +83,34 @@ trait ChartGeneration
         /** @var Account $account */
         foreach ($accounts as $account) {
             Log::debug(sprintf('Now at account #%d ("%s)', $account->id, $account->name));
-            $currency     = $accountRepos->getAccountCurrency($account) ?? $primary;
-            $usePrimary   = $convertToPrimary && $primary->id !== $currency->id;
-            $field        = $convertToPrimary ? 'pc_balance' : 'balance';
-            $currency     = $usePrimary ? $primary : $currency;
+            $nativeCurrency = $accountRepos->getAccountCurrency($account) ?? $primary;
+            $usePrimary     = $convertToPrimary && $primary->id !== $nativeCurrency->id;
+            $field          = $convertToPrimary ? 'pc_balance' : 'balance';
+            $currency       = $usePrimary ? $primary : $nativeCurrency;
+            $converter      = new ExchangeRateConverter();
             Log::debug(sprintf('Will use field %s', $field));
-            $currentSet   = ['label' => $account->name, 'currency_symbol' => $currency->symbol, 'entries' => []];
+            $currentSet     = ['label' => $account->name, 'currency_symbol' => $currency->symbol, 'entries' => []];
 
-            $currentStart = clone $start;
-            $range        = Steam::finalAccountBalanceInRange($account, clone $start, clone $end, $this->convertToPrimary);
-            $previous     = array_values($range)[0];
+            $currentStart   = clone $start;
+            $range          = Steam::finalAccountBalanceInRange($account, clone $start, clone $end, $this->convertToPrimary);
+            $previous       = array_values($range)[0];
             Log::debug(sprintf('Start balance for account #%d ("%s) is', $account->id, $account->name), $previous);
             while ($currentStart <= $end) {
                 $format                        = $currentStart->format('Y-m-d');
                 $label                         = trim($currentStart->isoFormat((string) trans('config.month_and_day_js', [], $locale)));
                 $balance                       = $range[$format] ?? $previous;
                 $previous                      = $balance;
+                $chartValue                    = $balance[$field] ?? '0';
+                if (
+                    $convertToPrimary
+                    && $nativeCurrency instanceof TransactionCurrency
+                    && $nativeCurrency->id !== $primary->id
+                    && array_key_exists($nativeCurrency->code, $balance)
+                ) {
+                    $chartValue = $converter->convert($nativeCurrency, $primary, clone $currentStart, (string) $balance[$nativeCurrency->code]);
+                }
+                $currentSet['entries'][$label] = $chartValue;
                 $currentStart->addDay();
-                $currentSet['entries'][$label] = $balance[$field] ?? '0';
             }
             $chartData[]  = $currentSet;
         }

--- a/tests/integration/Api/Models/Account/InvestmentValuationTest.php
+++ b/tests/integration/Api/Models/Account/InvestmentValuationTest.php
@@ -118,6 +118,62 @@ final class InvestmentValuationTest extends TestCase
         $this->showAccount($user, $asset)->assertJsonPath('data.attributes.pc_current_balance', '2.00');
     }
 
+    public function testDashboardOverviewChartRefreshesForeignCurrencyValuationAfterLaterRateChange(): void
+    {
+        $user        = $this->createUser('dashboard@example.com');
+        $asset       = $this->createInvestmentAccount($user, 'BTC dashboard');
+        $chartStart  = self::valuationDate()->clone()->startOfDay();
+        $chartEnd    = $chartStart->clone()->addDay();
+
+        $this->enablePrimaryConversion($user);
+        $this->createTransfer($user, $asset, '40000', '2');
+        $this->storeRate($user, '20000', $chartStart);
+
+        $initial = $this->showDashboardChart($user, $asset, $chartStart, $chartEnd);
+        $initial->assertOk();
+        self::assertSame('40000.00', array_values($initial->json()[0]['pc_entries'])[1]);
+
+        Passport::actingAs($user);
+        $storeResponse = $this->postJson(
+            route('api.v1.exchange-rates.store.by-currencies', [$this->btc->code, $this->eur->code]),
+            [$chartEnd->format('Y-m-d') => '25000']
+        );
+
+        $storeResponse->assertOk();
+
+        $updated = $this->showDashboardChart($user, $asset, $chartStart, $chartEnd);
+        $updated->assertOk();
+        self::assertSame('50000.00', array_values($updated->json()[0]['pc_entries'])[1]);
+    }
+
+    public function testClassicFrontpageDashboardChartRefreshesForeignCurrencyValuationAfterLaterRateChange(): void
+    {
+        $user        = $this->createUser('frontpage@example.com');
+        $asset       = $this->createInvestmentAccount($user, 'BTC frontpage');
+        $chartStart  = self::valuationDate()->clone()->startOfDay();
+        $chartEnd    = $chartStart->clone()->addDay();
+
+        $this->enablePrimaryConversion($user);
+        $this->createTransfer($user, $asset, '40000', '2');
+        $this->storeRate($user, '20000', $chartStart);
+
+        $initial = $this->showFrontpageDashboardChart($user, $asset, $chartStart, $chartEnd);
+        $initial->assertOk();
+        self::assertSame('40000.00', (string) $initial->json('datasets.0.data.1'));
+
+        Passport::actingAs($user);
+        $storeResponse = $this->postJson(
+            route('api.v1.exchange-rates.store.by-currencies', [$this->btc->code, $this->eur->code]),
+            [$chartEnd->format('Y-m-d') => '25000']
+        );
+
+        $storeResponse->assertOk();
+
+        $updated = $this->showFrontpageDashboardChart($user, $asset, $chartStart, $chartEnd);
+        $updated->assertOk();
+        self::assertSame('50000.00', (string) $updated->json('datasets.0.data.1'));
+    }
+
     #[Override]
     protected function setUp(): void
     {
@@ -234,9 +290,39 @@ final class InvestmentValuationTest extends TestCase
         return $this->getJson(route('api.v1.accounts.show', [$account]).'?date='.self::valuationDate()->format('Y-m-d'));
     }
 
-    private function storeRate(User $user, string $rate)
+    private function showDashboardChart(User $user, Account $account, Carbon $start, Carbon $end)
     {
-        $date = self::valuationDate()->clone()->startOfDay();
+        Passport::actingAs($user);
+        PreferencesSingleton::getInstance()->resetPreferences();
+
+        $params = http_build_query([
+            'start'    => $start->format('Y-m-d'),
+            'end'      => $end->format('Y-m-d'),
+            'period'   => '1D',
+            'accounts' => [$account->id],
+        ]);
+
+        return $this->getJson(route('api.v1.chart.account.overview').'?'.$params);
+    }
+
+    private function showFrontpageDashboardChart(User $user, Account $account, Carbon $start, Carbon $end)
+    {
+        $this->actingAs($user);
+        Preferences::setForUser($user, 'frontpageAccounts', [$account->id]);
+        PreferencesSingleton::getInstance()->resetPreferences();
+
+        return $this
+            ->withSession([
+                'start' => clone $start,
+                'end'   => clone $end,
+            ])
+            ->getJson(route('chart.account.frontpage'))
+        ;
+    }
+
+    private function storeRate(User $user, string $rate, ?Carbon $date = null)
+    {
+        $date ??= self::valuationDate()->clone()->startOfDay();
 
         return CurrencyExchangeRate::create([
             'user_id'          => $user->id,

--- a/tests/integration/Api/Models/Account/InvestmentValuationTest.php
+++ b/tests/integration/Api/Models/Account/InvestmentValuationTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\integration\Api\Models\Account;
+
+use Carbon\Carbon;
+use FireflyIII\Enums\AccountTypeEnum;
+use FireflyIII\Enums\TransactionTypeEnum;
+use FireflyIII\Models\Account;
+use FireflyIII\Models\AccountMeta;
+use FireflyIII\Models\CurrencyExchangeRate;
+use FireflyIII\Models\GroupMembership;
+use FireflyIII\Models\Transaction;
+use FireflyIII\Models\TransactionCurrency;
+use FireflyIII\Models\TransactionJournal;
+use FireflyIII\Models\TransactionType;
+use FireflyIII\Models\UserGroup;
+use FireflyIII\Models\UserRole;
+use Laravel\Passport\Passport;
+use FireflyIII\Support\Facades\FireflyConfig;
+use FireflyIII\Support\Facades\Preferences;
+use FireflyIII\Support\Singleton\PreferencesSingleton;
+use FireflyIII\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Override;
+use Tests\integration\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+final class InvestmentValuationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private TransactionCurrency $btc;
+    private TransactionCurrency $eur;
+
+    public function testForeignCurrencyAssetAccountGetsPrimaryValuation(): void
+    {
+        $user       = $this->createUser('investor@example.com');
+        $asset      = $this->createInvestmentAccount($user, 'BTC wallet');
+
+        $this->enablePrimaryConversion($user);
+        $this->createTransfer($user, $asset, '40000', '2');
+        $this->storeRate($user, '20000');
+
+        $response   = $this->showAccount($user, $asset);
+
+        $response->assertOk();
+        $response->assertJsonPath('data.attributes.current_balance', '2');
+        $response->assertJsonPath('data.attributes.pc_current_balance', '40000.00');
+    }
+
+    public function testUpdatingExchangeRateRefreshesInvestmentValuation(): void
+    {
+        $user       = $this->createUser('updater@example.com');
+        $asset      = $this->createInvestmentAccount($user, 'BTC stash');
+
+        $this->enablePrimaryConversion($user);
+        $this->createTransfer($user, $asset, '40000', '2');
+        $rate       = $this->storeRate($user, '20000');
+
+        $this->showAccount($user, $asset)->assertJsonPath('data.attributes.pc_current_balance', '40000.00');
+
+        Passport::actingAs($user);
+        $response   = $this->putJson(route('api.v1.exchange-rates.update', [$rate]), [
+            'date' => self::valuationDate()->format('Y-m-d'),
+            'rate' => '25000',
+        ]);
+
+        $response->assertOk();
+        $this->showAccount($user, $asset)->assertJsonPath('data.attributes.pc_current_balance', '50000.00');
+    }
+
+    public function testExchangeRateCachesStayIsolatedPerUserGroup(): void
+    {
+        $firstUser  = $this->createUser('group-a@example.com');
+        $secondUser = $this->createUser('group-b@example.com');
+        $firstAsset = $this->createInvestmentAccount($firstUser, 'BTC A');
+        $secondAsset = $this->createInvestmentAccount($secondUser, 'BTC B');
+
+        $this->enablePrimaryConversion($firstUser);
+        $this->enablePrimaryConversion($secondUser);
+
+        $this->createTransfer($firstUser, $firstAsset, '40000', '2');
+        $this->createTransfer($secondUser, $secondAsset, '40000', '2');
+
+        $this->storeRate($firstUser, '20000');
+        $this->storeRate($secondUser, '30000');
+
+        $this->showAccount($firstUser, $firstAsset)->assertJsonPath('data.attributes.pc_current_balance', '40000.00');
+        $this->showAccount($secondUser, $secondAsset)->assertJsonPath('data.attributes.pc_current_balance', '60000.00');
+    }
+
+    public function testBulkEndpointsInvalidateInvestmentValuationCaches(): void
+    {
+        $user       = $this->createUser('bulk@example.com');
+        $asset      = $this->createInvestmentAccount($user, 'BTC bulk');
+
+        $this->enablePrimaryConversion($user);
+        $this->createTransfer($user, $asset, '40000', '2');
+
+        Passport::actingAs($user);
+        $storeResponse = $this->postJson(
+            route('api.v1.exchange-rates.store.by-currencies', [$this->btc->code, $this->eur->code]),
+            [self::valuationDate()->format('Y-m-d') => '20000']
+        );
+
+        $storeResponse->assertOk();
+        $this->showAccount($user, $asset)->assertJsonPath('data.attributes.pc_current_balance', '40000.00');
+
+        $deleteResponse = $this->deleteJson(route('api.v1.exchange-rates.destroy', [$this->btc->code, $this->eur->code]));
+        $deleteResponse->assertNoContent();
+
+        $this->showAccount($user, $asset)->assertJsonPath('data.attributes.pc_current_balance', '2.00');
+    }
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->eur = TransactionCurrency::where('code', 'EUR')->firstOrFail();
+        $this->btc = TransactionCurrency::create([
+            'name'           => 'Bitcoin',
+            'code'           => 'BTC',
+            'symbol'         => 'BTC',
+            'decimal_places' => 8,
+            'enabled'        => true,
+        ]);
+    }
+
+    private function createCashAccount(User $user, string $name = 'Cash account'): Account
+    {
+        return $this->createAccountWithCurrency($user, $name, $this->eur);
+    }
+
+    private function createAccountWithCurrency(User $user, string $name, TransactionCurrency $currency): Account
+    {
+        $account = Account::factory()
+            ->for($user)
+            ->withType(AccountTypeEnum::ASSET)
+            ->create([
+                'user_group_id'    => $user->user_group_id,
+                'name'             => $name,
+                'virtual_balance'  => null,
+                'native_virtual_balance' => null,
+            ])
+        ;
+
+        AccountMeta::create([
+            'account_id' => $account->id,
+            'name'       => 'currency_id',
+            'data'       => $currency->id,
+        ]);
+
+        return $account;
+    }
+
+    private function createInvestmentAccount(User $user, string $name): Account
+    {
+        return $this->createAccountWithCurrency($user, $name, $this->btc);
+    }
+
+    private function createTransfer(User $user, Account $asset, string $eurAmount, string $btcAmount): void
+    {
+        $cashAccount   = $this->createCashAccount($user);
+        $transferType  = TransactionType::where('type', TransactionTypeEnum::TRANSFER->value)->firstOrFail();
+        $date          = self::valuationDate();
+        $journal       = TransactionJournal::create([
+            'user_id'                 => $user->id,
+            'user_group_id'           => $user->user_group_id,
+            'transaction_type_id'     => $transferType->id,
+            'transaction_currency_id' => $this->eur->id,
+            'description'             => 'Buy BTC',
+            'date'                    => $date,
+            'date_tz'                 => $date->format('e'),
+            'order'                   => 0,
+            'tag_count'               => 0,
+            'completed'               => true,
+        ]);
+
+        Transaction::create([
+            'account_id'              => $cashAccount->id,
+            'transaction_journal_id'  => $journal->id,
+            'description'             => null,
+            'transaction_currency_id' => $this->eur->id,
+            'amount'                  => '-'.$eurAmount,
+            'foreign_currency_id'     => $this->btc->id,
+            'foreign_amount'          => '-'.$btcAmount,
+            'identifier'              => 0,
+            'reconciled'              => false,
+        ]);
+
+        Transaction::create([
+            'account_id'              => $asset->id,
+            'transaction_journal_id'  => $journal->id,
+            'description'             => null,
+            'transaction_currency_id' => $this->btc->id,
+            'amount'                  => $btcAmount,
+            'foreign_currency_id'     => $this->eur->id,
+            'foreign_amount'          => $eurAmount,
+            'identifier'              => 0,
+            'reconciled'              => false,
+        ]);
+    }
+
+    private function createUser(string $email): User
+    {
+        $group = UserGroup::create(['title' => $email]);
+        $role  = UserRole::where('title', 'owner')->firstOrFail();
+        $user  = User::create(['email' => $email, 'password' => 'password', 'user_group_id' => $group->id]);
+
+        GroupMembership::create(['user_id' => $user->id, 'user_group_id' => $group->id, 'user_role_id' => $role->id]);
+
+        return $user;
+    }
+
+    private function enablePrimaryConversion(User $user): void
+    {
+        FireflyConfig::set('enable_exchange_rates', true);
+        Preferences::setForUser($user, 'convert_to_primary', true);
+        PreferencesSingleton::getInstance()->resetPreferences();
+    }
+
+    private function showAccount(User $user, Account $account)
+    {
+        Passport::actingAs($user);
+        PreferencesSingleton::getInstance()->resetPreferences();
+
+        return $this->getJson(route('api.v1.accounts.show', [$account]).'?date='.self::valuationDate()->format('Y-m-d'));
+    }
+
+    private function storeRate(User $user, string $rate)
+    {
+        $date = self::valuationDate()->clone()->startOfDay();
+
+        return CurrencyExchangeRate::create([
+            'user_id'          => $user->id,
+            'user_group_id'    => $user->user_group_id,
+            'from_currency_id' => $this->btc->id,
+            'to_currency_id'   => $this->eur->id,
+            'date'             => $date,
+            'date_tz'          => $date->format('e'),
+            'rate'             => $rate,
+        ]);
+    }
+
+    private static function valuationDate(): Carbon
+    {
+        return Carbon::create(2026, 3, 18, 12, 0, 0, 'UTC');
+    }
+}


### PR DESCRIPTION
@JC5

This PR fixes issue #11982.

Changes in this pull request:

- invalidate cached exchange-rate conversions when exchange rates are created, updated, or deleted
- refresh foreign currency account valuations shown in the primary currency after rate changes
- add integration coverage for rate updates and bulk rate changes affecting converted balances

Testing:
- `APP_KEY=$(php -r 'echo "base64:".base64_encode(random_bytes(32));') php artisan test tests/integration/Api/Models/Account/InvestmentValuationTest.php --no-coverage`
