### PR TITLE
Adjust $request->only() in testNotification function

### DIFF
--- a/app/Http/Controllers/Admin/NotificationController.php
+++ b/app/Http/Controllers/Admin/NotificationController.php
@@ -132,7 +132,7 @@ final class NotificationController extends Controller
             return redirect(route('settings.notification.index'));
         }
 
-        $all              = $request->only(['channel']);
+        $all              = $request->only(['test_submit']);
         $channel          = $all['test_submit'] ?? '';
 
         switch ($channel) {


### PR DESCRIPTION
<!--

🙌 Thanks for contributing a pull request. Before you continue:

1. If you introduce new financial solutions or concepts, talk to me FIRST.
2. If your PR is more than 25 lines, talk to me FIRST.
3. If you fix spelling or code comments, talk to me FIRST.

Wanna talk to me? Open a GitHub Issue, Discussion, or email me: james@firefly-iii.org

👀 Please ensure you have taken a look at the contribution guidelines:
https://docs.firefly-iii.org/explanation/support/#contributing-code

Remember that your PR may be CLOSED:

1. If you do not refer to an existing issue, your PR will be CLOSED.
2. If you open a PR on the main branch, your PR will be CLOSED.
3. If you only fix a spelling error or code comment, your PR will be CLOSED.

Thanks again, and happy developing!

-->

#### Reference issues and PRs
<!--
Example: Fixes #1234. See also #3456.
-->

See #12004

#### What does this implement/fix? Explain your changes.

Fixes the scope of $request->only() in testNotification to `test_submit` to fill the `$channel` variable.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://docs.firefly-iii.org/explanation/support/#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?

<!--
Thanks for contributing!
-->
