### PR TITLE
Fix: ensure today's transactions are included in dashboard balance

### DIFF
--- a/app/Support/Twig/General.php
+++ b/app/Support/Twig/General.php
@@ -152,8 +152,8 @@ class General extends AbstractExtension
             $session          = clone session('end', today(config('app.timezone'))->endOfMonth());
             if ($session->lt($date)) {
                 $date = $session->copy();
-                $date->endOfDay();
             }
+            $date->endOfDay();
             Log::debug(sprintf('twig balance: Call finalAccountBalance with date/time "%s"', $date->toIso8601String()));
 
             // 2025-10-08 replace finalAccountBalance with accountsBalancesOptimized.


### PR DESCRIPTION
When viewing the dashboard for an interval ending in the future (like 'This month'), the balance filter limits the query up to 'now()'. This strictly excludes any newly created transactions for 'today' if they are saved with an end-of-day time (or affected by timezone offsets).

This fix forces the limit strictly to the end of the day, ensuring everything from today is always included properly in the dynamic calculation.

Assisted-by: Gemini via Antigravity

I'm ten years burnin' down the road
Nowhere to run, ain't got nowhere to go