### PR TITLE
Fix overdue subscription alert threshold.

### DIFF
--- a/app/Jobs/WarnAboutBills.php
+++ b/app/Jobs/WarnAboutBills.php
@@ -48,6 +48,8 @@ class WarnAboutBills implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
+    private const OVERDUE_ALERT_DAYS = 2;
+
     private Carbon $date;
     private bool $force;
 
@@ -168,7 +170,7 @@ class WarnAboutBills implements ShouldQueue
         $diff     = $earliest->diffInDays($this->date);
         Log::debug(sprintf('Difference in days is %s', $diff));
 
-        return $diff >= 6; // FIXME hard coded value.
+        return $diff >= self::OVERDUE_ALERT_DAYS;
     }
 
     private function needsWarning(Bill $bill, string $field): bool


### PR DESCRIPTION
## Summary
- Align overdue subscription alerts with the documented 48-hour rule.
- Replace the stale 6-day hardcoded check with a named constant set to 2 days.
- Keep behavior explicit and easier to maintain.

## Test plan
- [ ] Run bill warning job against a subscription with oldest unpaid `pay_date` at 2+ days and verify overdue alert is emitted.
- [ ] Run same scenario with oldest unpaid `pay_date` < 2 days and verify no overdue alert.
- [ ] Confirm no regressions in standard bill reminder notifications.


Made with [Cursor](https://cursor.com)