### PR TITLE
implement password validation JS script in register blade

### DIFF
--- a/app/Http/Middleware/SecureHeaders.php
+++ b/app/Http/Middleware/SecureHeaders.php
@@ -63,7 +63,7 @@ class SecureHeaders
             "base-uri 'self'",
             // "form-action 'self'", // safe
             "font-src 'self' data:",
-            sprintf("connect-src 'self' %s", $trackingScriptSrc),
+            sprintf("connect-src 'self' https://api.pwnedpasswords.com %s", $trackingScriptSrc),
             sprintf("img-src 'self' data: 'nonce-%1s' ", $nonce),
             "manifest-src 'self'",
         ];

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -21,6 +21,10 @@
         </div>
     @endif
 
+    <div id="client-errors" class="alert alert-danger" role="alert" style="display:none;">
+        <ul id="client-errors-list"></ul>
+    </div>
+
     <div class="card">
         <div class="card-body register-card-body">
             <p class="login-box-msg">{{ trans('firefly.register_new_account') }}</p>
@@ -77,4 +81,84 @@
 @endsection
 @section('scripts')
     @vite(['src/pages/dashboard/dashboard.js'])
+    <script nonce="{{ $JS_NONCE }}">
+    (function () {
+        const form        = document.querySelector('form[action="{{ route('register') }}"]');
+        const errorBox    = document.getElementById('client-errors');
+        const errorList   = document.getElementById('client-errors-list');
+        const submitBtn   = form.querySelector('button[type="submit"]');
+        const originalBtnText = submitBtn.textContent;
+
+        function showErrors(errors) {
+            errorList.innerHTML = errors.map(function(e) { return '<li>' + e + '</li>'; }).join('');
+            errorBox.style.display = 'block';
+            errorBox.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        }
+
+        async function sha1Hex(str) {
+            const buf = await crypto.subtle.digest('SHA-1', new TextEncoder().encode(str));
+            return Array.from(new Uint8Array(buf))
+                .map(function(b) { return b.toString(16).padStart(2, '0'); })
+                .join('')
+                .toUpperCase();
+        }
+
+        async function isPwned(password) {
+            const hash   = await sha1Hex(password);
+            const prefix = hash.slice(0, 5);
+            const suffix = hash.slice(5);
+            const res    = await fetch('https://api.pwnedpasswords.com/range/' + prefix, {
+                headers: { 'Add-Padding': 'true' }
+            });
+            if (!res.ok) { return false; }
+            const text = await res.text();
+            return text.toUpperCase().split('\n').some(function(line) {
+                return line.split(':')[0] === suffix;
+            });
+        }
+
+        form.addEventListener('submit', async function (e) {
+            e.preventDefault();
+            errorBox.style.display = 'none';
+
+            const password = form.querySelector('[name="password"]').value;
+            const confirm  = form.querySelector('[name="password_confirmation"]').value;
+            const verify   = form.querySelector('[name="verify_password"]');
+            const errors   = [];
+
+            if (password.length < 16) {
+                errors.push('{{ trans('validation.min.string', ['attribute' => 'password', 'min' => 16]) }}');
+            }
+            if (password !== confirm) {
+                errors.push('{{ trans('validation.confirmed', ['attribute' => 'password']) }}');
+            }
+
+            if (errors.length > 0) {
+                showErrors(errors);
+                return;
+            }
+
+            if (verify && verify.checked) {
+                submitBtn.disabled    = true;
+                submitBtn.textContent = 'Checking password…';
+                try {
+                    if (await isPwned(password)) {
+                        errors.push('{{ trans('validation.secure_password') }}');
+                    }
+                } catch (_) {
+                    // network failure — let server validate
+                }
+                submitBtn.disabled    = false;
+                submitBtn.textContent = originalBtnText;
+            }
+
+            if (errors.length > 0) {
+                showErrors(errors);
+                return;
+            }
+
+            form.submit();
+        });
+    })();
+    </script>
 @endsection


### PR DESCRIPTION

#### What does this implement/fix? Explain your changes.
Fixes: https://github.com/firefly-iii/firefly-iii/issues/12176

Now, we can see client side errors when registering with password that fails to meet requirements:
<img width="560" height="731" alt="image" src="https://github.com/user-attachments/assets/382b4604-4e92-44ac-8fc0-e410d0aa6bd2" />

If having one issue:
<img width="500" height="680" alt="image" src="https://github.com/user-attachments/assets/538eebe5-d4d4-47d8-8df0-6cad6583eefc" />

Please note I have used AI to help me implement this feature, made sure that it it follows same code style as login blade and have reviewed it myself.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://docs.firefly-iii.org/explanation/support/#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding



@JC5

