### PR TITLE
fix shrinked sidebar expanding when navigating by clicking on icons

### DIFF
--- a/public/v1/js/ff/firefly.js
+++ b/public/v1/js/ff/firefly.js
@@ -70,13 +70,6 @@ $(function () {
         }, 0);
     });
 
-    (function () {
-        try {
-            if (localStorage.getItem('ff3_sidebar_collapsed') === '1') {
-                document.body.classList.add('sidebar-collapse');
-            }
-        } catch (_) {}
-    })();
 
 
     // on submit of form, disable any button in form:

--- a/public/v1/js/ff/firefly.js
+++ b/public/v1/js/ff/firefly.js
@@ -56,6 +56,20 @@ $(function () {
         return false;
     });
 
+    // save sidebar collapsed state when page loads.
+    $(document).on('click', '[data-toggle="push-menu"]', function () {
+        setTimeout(function () {
+            try {
+                if (window.localStorage) {
+                    localStorage.setItem(
+                        'ff3_sidebar_collapsed',
+                        $('body').hasClass('sidebar-collapse') ? '1' : '0'
+                    );
+                }
+            } catch (e) {}
+        }, 0);
+    });
+
     // on submit of form, disable any button in form:
     $('form.form-horizontal:not(.nodisablebutton)').on('submit', function () {
         $('button[type="submit"]').prop('disabled', true);

--- a/public/v1/js/ff/firefly.js
+++ b/public/v1/js/ff/firefly.js
@@ -70,6 +70,15 @@ $(function () {
         }, 0);
     });
 
+    (function () {
+        try {
+            if (localStorage.getItem('ff3_sidebar_collapsed') === '1') {
+                document.body.classList.add('sidebar-collapse');
+            }
+        } catch (_) {}
+    })();
+
+
     // on submit of form, disable any button in form:
     $('form.form-horizontal:not(.nodisablebutton)').on('submit', function () {
         $('button[type="submit"]').prop('disabled', true);

--- a/resources/views/layout/default.twig
+++ b/resources/views/layout/default.twig
@@ -95,16 +95,6 @@
 
 </head>
 <body class="skin-firefly-iii sidebar-mini hold-transition">
-<script type="text/javascript" nonce="{{ JS_NONCE }}">
-    // Restore sidebar collapsed state from localStorage before the rest of the page renders
-    (function () {
-        try {
-            if (localStorage.getItem('ff3_sidebar_collapsed') === '1') {
-                document.body.classList.add('sidebar-collapse');
-            }
-        } catch (_) {}
-    })();
-</script>
 <div class="wrapper" id="app">
 
     <header class="main-header">
@@ -308,19 +298,6 @@
     <input type="hidden" name="_token" value="{{ csrf_token() }}"/>
 </form>
 
-<script type="text/javascript" nonce="{{ JS_NONCE }}">
-    // Persist sidebar collapsed state across page loads
-    $(document).on('click', '[data-toggle="push-menu"]', function () {
-        setTimeout(function () {
-            try {
-                localStorage.setItem(
-                    'ff3_sidebar_collapsed',
-                    document.body.classList.contains('sidebar-collapse') ? '1' : '0'
-                );
-            } catch (_) {}
-        }, 0);
-    });
-</script>
 
 </body>
 </html>

--- a/resources/views/layout/default.twig
+++ b/resources/views/layout/default.twig
@@ -94,6 +94,16 @@
 
 </head>
 <body class="skin-firefly-iii sidebar-mini hold-transition">
+<script type="text/javascript" nonce="{{ JS_NONCE }}">
+    // get sidebar collapsed state from localStorage before the rest of the page renders
+    (function () {
+        try {
+            if (localStorage.getItem('ff3_sidebar_collapsed') === '1') {
+                document.body.classList.add('sidebar-collapse');
+            }
+        } catch (_) {}
+    })();
+</script>
 <div class="wrapper" id="app">
 
     <header class="main-header">

--- a/resources/views/layout/default.twig
+++ b/resources/views/layout/default.twig
@@ -92,8 +92,19 @@
     {# favicons #}
     {% include 'partials.favicons' %}
 
+
 </head>
 <body class="skin-firefly-iii sidebar-mini hold-transition">
+<script type="text/javascript" nonce="{{ JS_NONCE }}">
+    // Restore sidebar collapsed state from localStorage before the rest of the page renders
+    (function () {
+        try {
+            if (localStorage.getItem('ff3_sidebar_collapsed') === '1') {
+                document.body.classList.add('sidebar-collapse');
+            }
+        } catch (_) {}
+    })();
+</script>
 <div class="wrapper" id="app">
 
     <header class="main-header">
@@ -296,6 +307,20 @@
 <form id="logout-form" action="{{ route('logout') }}" method="POST" class="hidden">
     <input type="hidden" name="_token" value="{{ csrf_token() }}"/>
 </form>
+
+<script type="text/javascript" nonce="{{ JS_NONCE }}">
+    // Persist sidebar collapsed state across page loads
+    $(document).on('click', '[data-toggle="push-menu"]', function () {
+        setTimeout(function () {
+            try {
+                localStorage.setItem(
+                    'ff3_sidebar_collapsed',
+                    document.body.classList.contains('sidebar-collapse') ? '1' : '0'
+                );
+            } catch (_) {}
+        }, 0);
+    });
+</script>
 
 </body>
 </html>

--- a/resources/views/layout/default.twig
+++ b/resources/views/layout/default.twig
@@ -92,7 +92,6 @@
     {# favicons #}
     {% include 'partials.favicons' %}
 
-
 </head>
 <body class="skin-firefly-iii sidebar-mini hold-transition">
 <div class="wrapper" id="app">
@@ -297,7 +296,6 @@
 <form id="logout-form" action="{{ route('logout') }}" method="POST" class="hidden">
     <input type="hidden" name="_token" value="{{ csrf_token() }}"/>
 </form>
-
 
 </body>
 </html>


### PR DESCRIPTION

#### Reference issues and PRs


#### What does this implement/fix? Explain your changes.

Saving collapsed sidebar state in local storage and restoring it when a new page we navigate to loads.

<img width="550" height="438" alt="Apr-24-2026 15-52-15" src="https://github.com/user-attachments/assets/6a5c282a-99a7-4273-8a4d-7280bd59e797" />


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://docs.firefly-iii.org/explanation/support/#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?

<!--
Thanks for contributing!
-->

@JC5

