### PR TITLE
ci: pin github-action-get-latest-release to a full commit SHA

### DIFF
--- a/.github/workflows/issues-reply-old-versions.yml
+++ b/.github/workflows/issues-reply-old-versions.yml
@@ -17,14 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: ff3version
-        uses: pozetroninc/github-action-get-latest-release@master
+        uses: pozetroninc/github-action-get-latest-release@53d33d213ee71c72360e3c829caf7cee94ec21e2 # pins @master
         with:
           owner: firefly-iii
           repo: firefly-iii
           excludes: prerelease, draft
           token: ${{ secrets.GITHUB_TOKEN }}
       - id: importerversion
-        uses: pozetroninc/github-action-get-latest-release@master
+        uses: pozetroninc/github-action-get-latest-release@53d33d213ee71c72360e3c829caf7cee94ec21e2 # pins @master
         with:
           owner: firefly-iii
           repo: data-importer


### PR DESCRIPTION
Re-opening against `develop` as requested in #12496 (thanks @JC5!).

## What
Pin `pozetroninc/github-action-get-latest-release` in `issues-reply-old-versions.yml` (both steps) from the mutable `@master` branch to the commit it resolves to.

## Why
Each step passes `token: ${{ secrets.GITHUB_TOKEN }}` to this third-party action (a personal repo), and the workflow grants `issues: write` + `pull-requests: write`. Referenced by the moving `@master` branch, the exact code that runs with that token can change without any change here — the third-party-action supply-chain risk GitHub's hardening guidance addresses with a full commit SHA. Behaviour unchanged (`53d33d2` is the current tip of master).

I used AI assistance to identify this and draft the change; I verified it against the live workflow myself.