### PR TITLE
Add tags to Edit selected individually (mass edit)

### DIFF
--- a/app/Http/Controllers/Transaction/MassController.php
+++ b/app/Http/Controllers/Transaction/MassController.php
@@ -244,6 +244,24 @@ final class MassController extends Controller
         return (string) $value[$journalId];
     }
 
+    private function getTagsFromRequest(MassEditJournalRequest $request, int $journalId): ?array
+    {
+        $value = $request->input('tags');
+        if (!is_array($value) || !array_key_exists($journalId, $value)) {
+            return null;
+        }
+
+        $string = trim((string) $value[$journalId]);
+        if ('' === $string) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map(trim(...), explode(',', $string)),
+            static fn (string $tag): bool => '' !== $tag
+        ));
+    }
+
     /**
      * @throws FireflyException
      */
@@ -271,6 +289,10 @@ final class MassController extends Controller
             'amount'           => $this->getStringFromRequest($request, $journal->id, 'amount'),
             'foreign_amount'   => $this->getStringFromRequest($request, $journal->id, 'foreign_amount'),
         ];
+        $tags    = $this->getTagsFromRequest($request, $journal->id);
+        if (null !== $tags) {
+            $data['tags'] = $tags;
+        }
         Log::debug(sprintf('Will update journal #%d with data.', $journal->id), $data);
 
         // call service to update.

--- a/app/Http/Requests/MassEditJournalRequest.php
+++ b/app/Http/Requests/MassEditJournalRequest.php
@@ -49,6 +49,7 @@ class MassEditJournalRequest extends FormRequest
             'source_id.*'      => ['numeric', 'belongsToUser:accounts,id'],
             'destination_id.*' => ['numeric', 'belongsToUser:accounts,id'],
             'journals.*'       => ['numeric', 'belongsToUser:transaction_journals,id'],
+            'tags.*'           => ['nullable', 'max:1024'],
             'revenue_account'  => 'max:255',
             'expense_account'  => 'max:255',
         ];

--- a/public/v1/js/ff/transactions/mass/edit.js
+++ b/public/v1/js/ff/transactions/mass/edit.js
@@ -130,4 +130,41 @@ $(document).ready(function () {
 
     $('input[name^="category["]').typeahead({hint: true, highlight: true,}, {source: categories, displayKey: 'name', autoSelect: false});
 
+    // tags
+    if ($('input[name^="tags["]').length > 0) {
+        console.log('Tags.');
+        var tagTags = new Bloodhound({
+                                         datumTokenizer: Bloodhound.tokenizers.obj.whitespace('name'),
+                                         queryTokenizer: Bloodhound.tokenizers.whitespace,
+                                         prefetch: {
+                                             url: 'api/v1/autocomplete/tags?uid=' + uid,
+                                             filter: function (list) {
+                                                 return $.map(list, function (item) {
+                                                     return {name: item.name};
+                                                 });
+                                             }
+                                         },
+                                         remote: {
+                                             url: 'api/v1/autocomplete/tags?query=%QUERY&uid=' + uid,
+                                             wildcard: '%QUERY',
+                                             filter: function (list) {
+                                                 return $.map(list, function (item) {
+                                                     return {name: item.name};
+                                                 });
+                                             }
+                                         }
+                                     });
+        tagTags.initialize();
+        $('input[name^="tags["]').tagsinput({
+                                                typeaheadjs: {
+                                                    hint: true,
+                                                    highlight: true,
+                                                    name: 'tags',
+                                                    displayKey: 'name',
+                                                    valueKey: 'name',
+                                                    source: tagTags.ttAdapter()
+                                                }
+                                            });
+    }
+
 });

--- a/resources/views/transactions/mass/edit.blade.php
+++ b/resources/views/transactions/mass/edit.blade.php
@@ -23,8 +23,9 @@
                                 <th class="col-lg-1 col-md-1 col-sm-1">{{ trans('list.date') }}</th>
                                 <th class="col-lg-2 col-md-2 col-sm-2">{{ trans('list.from') }}</th>
                                 <th class="col-lg-2 col-md-2 col-sm-2">{{ trans('list.to') }}</th>
-                                <th class="col-lg-2 col-md-2 col-sm-2">{{ trans('list.category') }}</th>
-                                <th class="col-lg-2 col-md-2 col-sm-2">{{ trans('list.budget') }}</th>
+                                <th class="col-lg-1 col-md-1 col-sm-1">{{ trans('list.category') }}</th>
+                                <th class="col-lg-1 col-md-1 col-sm-1">{{ trans('list.budget') }}</th>
+                                <th class="col-lg-2 col-md-2 col-sm-2">{{ trans('list.tags') }}</th>
                             </tr>
                             @foreach($journals as $journal)
                                 <tr>
@@ -159,6 +160,12 @@
                                             </select>
                                         @endif
                                     </td>
+                                    {{-- tags --}}
+                                    <td>
+                                        <input class="form-control input-sm" placeholder="" autocomplete="off" spellcheck="false"
+                                               name="tags[{{ $journal['transaction_journal_id'] }}]" type="text"
+                                               value="@foreach($journal['tags'] ?? [] as $tag){{ $tag['name'] }}@if(!$loop->last),@endif@endforeach">
+                                    </td>
                                 </tr>
                             @endforeach
                         </table>
@@ -179,8 +186,9 @@
     </script>
     <script type="text/javascript" src="v1/js/lib/typeahead/typeahead.bundle.min.js?v={{ $FF_BUILD_TIME }}" nonce="{{ $JS_NONCE }}"></script>
     <script type="text/javascript" src="v1/js/ff/common/autocomplete.js?v={{ $FF_BUILD_TIME }}" nonce="{{ $JS_NONCE }}"></script>
+    <script type="text/javascript" src="v1/js/lib/bootstrap-tagsinput.min.js?v={{ $FF_BUILD_TIME }}" nonce="{{ $JS_NONCE }}"></script>
     <script type="text/javascript" src="v1/js/ff/transactions/mass/edit.js?v={{ $FF_BUILD_TIME }}" nonce="{{ $JS_NONCE }}"></script>
 @endsection
-@section('scripts')
-    @vite(['js/pages/generic.js'])
+@section('styles')
+    <link href="v1/css/bootstrap-tagsinput.css?v={{ $FF_BUILD_TIME }}" type="text/css" rel="stylesheet" media="all" nonce="{{ $JS_NONCE }}">
 @endsection


### PR DESCRIPTION
## Summary
- Fixes #12535 (revisit of #3691)
- Adds a tags field per row on the individual mass-edit page (/transactions/mass/edit/...)
- Prefills current tags; supports add / remove / clear, same tagsinput as bulk edit

## Test plan
- [ ] Open expenses (or uncategorised) list, select several transactions, choose Edit selected individually
- [ ] Confirm Tags column shows, with existing tags as pills where present
- [ ] Add a tag to one row, remove a tag from another, clear tags on a third
- [ ] Submit and verify tags persisted (transaction show / API)
- [ ] Confirm category/budget/description still save as before