### PR TITLE
Default USE_RUNNING_BALANCE to false (disabled), matching the GUI text

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -299,3 +299,9 @@ FIREFLY_III_LAYOUT=v1
 # It is used to validate specific requests and to generate URLs in emails.
 #
 APP_URL=http://localhost
+
+#
+# The running balance feature is experimental and disabled by default.
+# Set to true to enable it. You may need to restart your container afterwards.
+#
+USE_RUNNING_BALANCE=false

--- a/app/Api/V1/Controllers/System/ConfigurationController.php
+++ b/app/Api/V1/Controllers/System/ConfigurationController.php
@@ -153,7 +153,7 @@ final class ConfigurationController extends Controller
         $singleUser            = AppConfiguration::get('single_user_mode', true);
         $lastCheck             = AppConfiguration::get('last_update_check', 1);
         $enableExchangeRates   = AppConfiguration::get('enable_exchange_rates', config('cer.enabled'));
-        $useRunningBalance     = AppConfiguration::get('use_running_balance', true);
+        $useRunningBalance     = AppConfiguration::get('use_running_balance', config('firefly.feature_flags.running_balance_column'));
         $enableExternalMap     = AppConfiguration::get('enable_external_map', false);
         $enableExternalRates   = AppConfiguration::get('enable_external_rates', false);
         $allowWebhooks         = AppConfiguration::get('allow_webhooks', false);

--- a/config/firefly.php
+++ b/config/firefly.php
@@ -75,7 +75,7 @@ return [
         'webhooks'               => true,
         'handle_debts'           => true,
         'expression_engine'      => true,
-        'running_balance_column' => (bool)env_default_when_empty(env('USE_RUNNING_BALANCE'), true), // this is only the default value, is not used.
+        'running_balance_column' => (bool)env_default_when_empty(env('USE_RUNNING_BALANCE'), false), // fallback value, used when the configuration has not been stored in the database yet.
         // see cer.php for exchange rates feature flag.
     ],
 'version' => '6.6.6',


### PR DESCRIPTION
## What

`USE_RUNNING_BALANCE` currently defaults to **true**, which contradicts the GUI settings text that says the running-balance feature is "slightly experimental, so **disabled by default**". Because neither `.env.example` nor the docker-compose template contains a `USE_RUNNING_BALANCE` line, every fresh deployment that follows the docs silently enables the feature — and creating a transaction then triggers a full-database running-balance recalculation (measured ~8s per transaction during a large import; under a second after disabling it).

This PR:

1. `config/firefly.php` — changes the fallback from `true` to `false`, matching the GUI text, and fixes the misleading `// this is only the default value, is not used.` comment: the value **is** used as the fallback by `AppConfiguration::get()` at several call sites.
2. `app/Api/V1/Controllers/System/ConfigurationController.php` — uses the same config fallback as the other six call sites instead of a hardcoded `true` (otherwise the API would still report `use_running_balance=true` on fresh installs).
3. `.env.example` — documents `USE_RUNNING_BALANCE` so the toggle is discoverable.

## Why

- Fixes #12623
- Related: #11531 (running-balance recalculation was still executed after disabling — fixed recently), which shows the feature has known performance issues and should stay opt-in.

## Verification

- No tests reference `running_balance`, so no test changes are required.
- Behavior: on a fresh install (no `USE_RUNNING_BALANCE` set, no stored configuration) `config('firefly.feature_flags.running_balance_column')` now returns `false`; the GUI checkbox, the API response and the actual recalculation behavior now agree. Existing installations with the value stored in the database are unaffected.
