### PR TITLE
Fix recurring transaction API validation for moment >10

### DIFF
--- a/app/Api/V1/Requests/Models/Recurrence/StoreRequest.php
+++ b/app/Api/V1/Requests/Models/Recurrence/StoreRequest.php
@@ -88,7 +88,7 @@ class StoreRequest extends FormRequest
             'nr_of_repetitions'                    => ['nullable', 'numeric', 'min:1', 'max:255'],
 
             'repetitions.*.type'                   => ['required', 'in:daily,weekly,ndom,monthly,yearly'],
-            'repetitions.*.moment'                 => ['min:0', 'max:10'],
+            'repetitions.*.moment'                 => ['nullable'],
             'repetitions.*.skip'                   => ['nullable', 'numeric', 'min:0', 'max:31'],
             'repetitions.*.weekend'                => ['numeric', 'min:1', 'max:4'],
 

--- a/app/Api/V1/Requests/Models/Recurrence/UpdateRequest.php
+++ b/app/Api/V1/Requests/Models/Recurrence/UpdateRequest.php
@@ -97,7 +97,7 @@ class UpdateRequest extends FormRequest
             'nr_of_repetitions'                    => ['nullable', 'numeric', 'min:1', 'max:255'],
 
             'repetitions.*.type'                   => 'in:daily,weekly,ndom,monthly,yearly',
-            'repetitions.*.moment'                 => ['min:0', 'max:10', 'numeric'],
+            'repetitions.*.moment'                 => ['nullable'],
             'repetitions.*.skip'                   => ['nullable', 'numeric', 'min:0', 'max:31'],
             'repetitions.*.weekend'                => ['nullable', 'numeric', 'min:1', 'max:4'],
 


### PR DESCRIPTION
#### Reference issues and PRs
Fixes #12545

#### What does this implement/fix? Explain your changes.
Monthly recurrences with `moment` 11-31 were rejected via API with "may not be greater than 10" while the web UI and OpenAPI allow 1-31. This relaxes the generic validation so the existing type-specific validation decides.

#### AI usage disclosure
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Any other comments?
Keeps the fix minimal to two lines and preserves all type-specific validation.

@JC5